### PR TITLE
docs(readme): guia de uso do board e do fluxo de trabalho

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,29 @@ persistência real.
 
 > **Status:** repositório em fundação. O código da aplicação ainda não foi commitado —
 > o backlog de implementação está nas [issues](../../issues) e no
-> [board](../../projects).
+> [board](https://github.com/users/AlexCajeFelix/projects/4).
+
+**Comece pela issue [#1](../../issues/1) e depois a [#2](../../issues/2).** Elas destravam
+todo o resto do backlog — nada de M2 em diante deve começar antes delas.
+
+---
+
+## Índice
+
+- [Stack alvo](#stack-alvo)
+- [Arquitetura pretendida](#arquitetura-pretendida)
+- [Como trabalhar aqui](#como-trabalhar-aqui) ← **comece por aqui**
+  - [O board](#o-board)
+  - [Fluxo completo de uma task](#fluxo-completo-de-uma-task)
+  - [Abrindo uma issue nova](#abrindo-uma-issue-nova)
+  - [Labels](#labels)
+  - [Campos do board](#campos-do-board)
+  - [Branches e commits](#branches-e-commits)
+  - [Regras da main](#regras-da-main)
+- [Milestones](#milestones)
+- [Colinha de comandos](#colinha-de-comandos)
+
+---
 
 ## Stack alvo
 
@@ -31,43 +53,363 @@ persistência real.
 - **Auditoria financeira** em `project_metrics_history` — todo `PATCH` de métrica grava snapshot.
 - **Erros padronizados** em RFC 7807 por um `GlobalExceptionHandler` central.
 
-## Convenções
+---
+
+# Como trabalhar aqui
+
+## O board
+
+**→ https://github.com/users/AlexCajeFelix/projects/4**
+
+Cinco colunas. A regra que mantém o board honesto: **o card mora numa coluna só, e quem move é
+quem está com ele na mão.**
+
+| Coluna | O que significa | Quando mover para cá |
+|---|---|---|
+| **Backlog** | Existe, mas ainda não pode ou não deve começar | Nasce aqui |
+| **Pronto** | Destravado, com critério de aceite claro, pode pegar | Quando as dependências fecharam |
+| **Em andamento** | Alguém está tocando **agora** | Ao criar a branch |
+| **Em revisão** | PR aberto esperando review | Ao abrir o PR |
+| **Concluído** | Mergeado e validado | Merge do PR (automático, ver abaixo) |
+
+**Limite de trabalho em paralelo:** no máximo **2 cards** em `Em andamento` por pessoa. Mais que
+isso e nada termina — só existe coisa pela metade.
+
+Se um card está em `Em andamento` e você parou de mexer nele, mova de volta para `Pronto`. Card
+parado em andamento é a mentira mais comum de board de Kanban.
+
+### Mover um card
+
+**Pelo navegador (o jeito normal):** arraste o card entre as colunas.
+
+**Pelo terminal**, se você já está no fluxo do `gh`:
+
+```bash
+# 1) achar o ID do item (o card) a partir do numero da issue
+gh project item-list 4 --owner @me --format json \
+  | jq -r '.items[] | select(.content.number == 15) | .id'
+
+# 2) mover para "Em andamento"
+gh project item-edit \
+  --id <ITEM_ID_DO_PASSO_1> \
+  --project-id PVT_kwHOC3YJlc4BgXof \
+  --field-id PVTSSF_lAHOC3YJlc4BgXofzhakCuM \
+  --single-select-option-id f5cb7ae8
+```
+
+Os IDs das colunas (nada disso é adivinhável, por isso está anotado aqui):
+
+| Coluna | `--single-select-option-id` |
+|---|---|
+| Backlog | `d2215c36` |
+| Pronto | `ee5638cc` |
+| Em andamento | `f5cb7ae8` |
+| Em revisão | `5183676e` |
+| Concluído | `f0a034ae` |
+
+> Se algum dia esses IDs não baterem, **não invente** — releia com
+> `gh project field-list 4 --owner @me --format json`.
+
+### Fechamento automático
+
+O card vai sozinho para `Concluído` quando o PR que diz `Closes #N` é mergeado. É por isso que
+o `Closes #` no template de PR não é enfeite: sem ele, você fecha a issue na mão e o board
+desatualiza.
+
+---
+
+## Fluxo completo de uma task
+
+Do "peguei" ao "acabou". Exemplo com a issue **#15**.
+
+### 1. Pegue o card
+
+Escolha algo em **`Pronto`** — não em `Backlog`. Se está no Backlog, ou tem dependência aberta ou
+ninguém ainda decidiu que vale a pena.
+
+```bash
+gh issue view 15                      # leia o critério de aceite ANTES de codar
+gh issue edit 15 --add-assignee @me
+```
+
+Mova o card para **`Em andamento`**.
+
+### 2. Crie a branch
+
+Sempre a partir da `main` atualizada:
+
+```bash
+git checkout main
+git pull
+git checkout -b test/integracao-ideias
+```
+
+### 3. Trabalhe, commitando pequeno
+
+```bash
+git add -A
+git commit -m "test(idea): cobre submissao e listagem filtrada"
+```
+
+O critério de aceite da issue é a sua checklist. Vá marcando os checkboxes na própria issue
+conforme fecha cada item — dá visibilidade sem ninguém precisar perguntar "como tá?".
+
+### 4. Rode o build antes de abrir o PR
+
+```bash
+./mvnw -q verify
+```
+
+Abrir PR vermelho gasta o tempo de quem revisa. (Enquanto a issue #1 não fechar, esse comando
+ainda não existe.)
+
+### 5. Abra o PR
+
+```bash
+git push -u origin test/integracao-ideias
+gh pr create --fill
+```
+
+Preencha o template — principalmente o **`Closes #15`** e o **como validar**. Mova o card para
+**`Em revisão`**.
+
+### 6. Review
+
+Comentário pendente **bloqueia o merge** (a `main` exige conversas resolvidas). Resolva ou
+responda cada um.
+
+### 7. Merge
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+Use **squash**: a `main` exige histórico linear, então merge commit é rejeitado.
+
+O card vai para `Concluído` sozinho por causa do `Closes #15`. Fim.
+
+---
+
+## Abrindo uma issue nova
+
+**Pelo navegador:** *Issues → New issue* → escolha **Bug** ou **Feature**. Os templates já pedem
+área, contexto e critério de aceite nos campos certos.
+
+**Pelo terminal:**
+
+```bash
+gh issue create \
+  --title "Cache de resposta do dashboard" \
+  --label tipo:feat --label area:backend --label p2 --label size:m \
+  --milestone "M3 — Operação"
+```
+
+Depois adicione ao board:
+
+```bash
+gh project item-add 4 --owner @me \
+  --url https://github.com/AlexCajeFelix/FIAP-AGUIA-BRANCA/issues/28
+```
+
+### O que faz uma issue boa aqui
+
+Toda issue segue três seções:
+
+```markdown
+## Contexto
+Por que isso existe — 2-3 linhas, citando arquivos reais.
+
+## Critério de aceite
+- [ ] item verificável
+- [ ] item verificável
+
+## Notas técnicas
+Armadilhas, arquivos a tocar, comandos.
+```
+
+**A regra do critério de aceite:** cada checkbox tem que ser verificável por alguém que não
+escreveu o código.
+
+| ❌ Não serve | ✅ Serve |
+|---|---|
+| "funcionar corretamente" | "`GET /ideas/{id}` de ideia alheia responde 404 para `OPERADOR`" |
+| "estar seguro" | "app não sobe se `JWT_SECRET` tiver menos de 32 bytes" |
+| "ter boa performance" | "query executa em menos de 200 ms com 100k projetos" |
+
+Se você não consegue escrever como verificar, a issue ainda não está pronta para sair do Backlog.
+
+---
+
+## Labels
+
+Quatro famílias. **Toda issue leva uma de cada** — é o que faz os filtros funcionarem.
+
+| Família | Valores | Para quê |
+|---|---|---|
+| **Tipo** | `tipo:feat` `tipo:fix` `tipo:chore` `tipo:docs` `tipo:test` `tipo:seguranca` | Natureza do trabalho |
+| **Área** | `area:backend` `area:android` `area:infra` `area:banco` | Onde encosta |
+| **Prioridade** | `p0` `p1` `p2` | Ordem de ataque |
+| **Tamanho** | `size:s` `size:m` `size:l` | Esforço estimado |
+
+**Prioridade:**
+
+- `p0` — **bloqueia outras frentes.** Alguém está parado por causa disso.
+- `p1` — importante, entra no ciclo atual.
+- `p2` — pode esperar sem prejuízo.
+
+**Tamanho:**
+
+- `size:s` — até meio dia
+- `size:m` — 1 a 2 dias
+- `size:l` — 3 dias ou mais → **considere quebrar em issues menores**
+
+Filtrando:
+
+```bash
+gh issue list --label p0 --state open              # o que trava o time
+gh issue list --label area:android                 # backlog do app
+gh issue list --milestone "M1 — Repo e CI"
+gh issue list --search "no:assignee label:p0"      # p0 sem dono
+```
+
+---
+
+## Campos do board
+
+Além do Status, cada card tem dois campos próprios:
+
+| Campo | Tipo | Valores |
+|---|---|---|
+| **Área** | seleção | Backend, Android, Infra, Banco |
+| **Estimativa** | número | pontos de esforço |
+
+A **Estimativa** segue o tamanho, para o board somar por coluna:
+
+| Label | Estimativa |
+|---|---|
+| `size:s` | 1 |
+| `size:m` | 3 |
+| `size:l` | 5 |
+
+No board dá para agrupar por `Área` em vez de Status (**⋯ → Group by**) quando você quer olhar
+só a frente Android, por exemplo.
+
+---
+
+## Branches e commits
 
 ### Branches
 
-- `main` — protegida. Sem push direto, PR obrigatório, CI verde obrigatório.
-- `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `docs/<slug>`, `test/<slug>`
+Sempre a partir da `main`, no formato `<tipo>/<slug-curto>`:
+
+```
+feat/refresh-token
+fix/tipo-count-jpql
+chore/maven-wrapper
+docs/guia-contribuicao
+test/matriz-rbac
+```
+
+Uma branch por issue. Branch de vida longa vira conflito de merge.
 
 ### Commits
 
-[Conventional Commits](https://www.conventionalcommits.org/):
+[Conventional Commits](https://www.conventionalcommits.org/) — `<tipo>(<escopo>): <o que muda>`:
 
 ```
 feat(idea): adiciona endpoint de aprovacao
 fix(project): corrige tipo do COUNT na constructor expression
 chore(ci): adiciona cache de dependencias maven
+test(auth): cobre token expirado e assinatura invalida
+docs(readme): documenta fluxo do board
 ```
 
-### Labels
+Escopo é a fatia ou o módulo (`idea`, `project`, `auth`, `strategy`, `ci`, `android`).
+Escreva no **imperativo** e descreva o efeito, não o arquivo: `corrige tipo do COUNT`, não
+`altera ProjectRepository`.
 
-| Família | Valores |
+---
+
+## Regras da main
+
+A `main` é protegida — **e a regra vale para admin também**, então não adianta ser o dono do repo.
+
+| Regra | Efeito prático |
 |---|---|
-| Tipo | `tipo:feat` `tipo:fix` `tipo:chore` `tipo:docs` `tipo:test` `tipo:seguranca` |
-| Área | `area:backend` `area:android` `area:infra` `area:banco` |
-| Prioridade | `p0` (bloqueia) `p1` (importante) `p2` (pode esperar) |
-| Tamanho | `size:s` `size:m` `size:l` |
+| Push direto bloqueado | `git push origin main` é rejeitado com `GH006` |
+| PR obrigatório | Todo código entra por PR |
+| Histórico linear | Merge commit rejeitado — **use `--squash`** |
+| Conversas resolvidas | Comentário pendente trava o merge |
+| Force push bloqueado | Não dá para reescrever o histórico |
+| Deleção bloqueada | A `main` não some por acidente |
+
+Se você tentar `git push origin main` e vir isso, **está tudo certo**:
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - Changes must be made through a pull request.
+```
+
+Commitou na `main` local por engano? Leve o trabalho para uma branch:
+
+```bash
+git branch minha-branch      # salva o ponto atual
+git reset --hard origin/main # limpa a main local
+git checkout minha-branch
+```
+
+### Ainda não está ligado
+
+Duas regras ficaram de fora de propósito, e a issue [#5](../../issues/5) existe para fechá-las:
+
+- **CI verde obrigatório** — depende do workflow da [#3](../../issues/3) existir. Não dá para
+  exigir um check que nunca rodou: isso travaria todo PR permanentemente.
+- **Aprovação obrigatória** — hoje há um único colaborador com write, e o GitHub não deixa
+  ninguém aprovar o próprio PR. Sobe para 1 assim que entrar a segunda pessoa.
+
+---
 
 ## Milestones
 
-| Milestone | Objetivo |
-|---|---|
-| M1 — Repo e CI | Build reproduzível e pipeline verde |
-| M2 — Endurecimento | Segurança e config prontas para ambiente real |
-| M3 — Operação | Observabilidade, empacotamento, performance |
-| M4 — Testes | Cobertura por fatia e matriz de RBAC |
-| M5 — Integração Android | App sai do mock e passa a consumir a API |
+| Milestone | Objetivo | Issues |
+|---|---|---|
+| **M1** — Repo e CI | Build reproduzível e pipeline verde | [#1–#5](../../milestone/1) |
+| **M2** — Endurecimento | Segurança e config prontas para ambiente real | [#6–#10](../../milestone/2) |
+| **M3** — Operação | Observabilidade, empacotamento, performance | [#11–#14](../../milestone/3) |
+| **M4** — Testes | Cobertura por fatia e matriz de RBAC | [#15–#19](../../milestone/4) |
+| **M5** — Integração Android | App sai do mock e passa a consumir a API | [#20–#26](../../milestone/5) |
 
-## Ordem de ataque
+A ordem não é rígida entre M2, M3 e M4 — mas **M1 vem antes de tudo**, e o M5 depende do
+contrato OpenAPI da [#20](../../issues/20) estar publicado.
 
-As issues **#1 (Maven Wrapper)** e **#2 (build verde)** destravam todo o resto.
-Nada de M2 em diante deve começar antes delas.
+---
+
+## Colinha de comandos
+
+```bash
+# --- ver trabalho ---
+gh issue list --state open                    # tudo que está aberto
+gh issue list --label p0                      # o que bloqueia
+gh issue list --assignee @me                  # o que é meu
+gh issue view 15                              # ler uma issue
+gh project item-list 4 --owner @me            # o board no terminal
+
+# --- pegar uma task ---
+gh issue edit 15 --add-assignee @me
+git checkout main && git pull
+git checkout -b test/integracao-ideias
+
+# --- entregar ---
+./mvnw -q verify
+git push -u origin test/integracao-ideias
+gh pr create --fill
+gh pr checks                                  # o CI passou?
+gh pr merge --squash --delete-branch
+
+# --- inspecionar o board (quando os IDs mudarem) ---
+gh project field-list 4 --owner @me --format json
+gh project item-list 4 --owner @me --format json
+```
+
+> `gh project` exige os scopes `project` e `read:project` no token. Se der erro de scope:
+> `gh auth refresh -s project,read:project,workflow,repo`


### PR DESCRIPTION
Deixa o README respondendo "como eu trabalho aqui" sem ninguém precisar perguntar.

Adiciona:

- **O board** — o que cada uma das 5 colunas significa e o gatilho para mover o card; limite de 2 cards em andamento por pessoa; como mover pelo navegador e pela CLI, com os IDs reais anotados (projeto, campo Status e cada coluna) para não depender de adivinhar identificador
- **Fluxo completo de uma task** — do `--add-assignee` ao `--squash --delete-branch`, em 7 passos com os comandos
- **Abrindo issue** — as três seções obrigatórias e uma tabela de critério de aceite ruim vs. bom
- **Labels** — as quatro famílias, o que cada prioridade e tamanho significam, e os filtros úteis
- **Campos do board** — Área e a escala de Estimativa (s=1, m=3, l=5)
- **Branches e commits** — formato e exemplos reais do projeto
- **Regras da main** — o que está ativo, por que `--squash` é obrigatório, como reagir ao `GH006` e como recuperar commit feito na main por engano
- **Colinha de comandos** no fim

Documenta também as duas regras de proteção que ficaram desligadas de propósito, apontando para a #5.

## Como validar

Só documentação — nada de código. Leia o README renderizado e confira que os links de issue e milestone abrem.

- [ ] Os IDs de coluna batem com `gh project field-list 4 --owner @me --format json`
- [ ] Os links `../../issues/N` e `../../milestone/N` resolvem

Relacionado a #4 — **não fecha**: o CODEOWNERS com donos reais e o `config.yml` de ISSUE_TEMPLATE continuam pendentes lá.