### PR TITLE
fix: validar compilacao e estruturar entidades do build inicial

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,16 +25,71 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<compilerArgs>
+						<arg>-Xlint:all</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/Idea.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/Idea.java
@@ -1,0 +1,85 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+@Entity
+@Table(name = "ideas")
+public class Idea {
+
+    public enum Status {
+        DRAFT,
+        IN_REVIEW,
+        APPROVED,
+        REJECTED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "Título é obrigatório")
+    private String title;
+
+    @NotBlank(message = "Descrição é obrigatória")
+    private String description;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Status status = Status.DRAFT;
+
+    public Idea() {
+    }
+
+    public Idea(String title, String description) {
+        this.title = title;
+        this.description = description;
+        this.status = Status.DRAFT;
+    }
+
+    public void review(Status newStatus) {
+        if (newStatus == null || newStatus == Status.DRAFT) {
+            throw new IllegalArgumentException("Status de revisão inválido");
+        }
+        this.status = newStatus;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Idea idea = (Idea) o;
+        return Objects.equals(id, idea.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/Project.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/Project.java
@@ -1,0 +1,79 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@Entity
+@Table(name = "projects")
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "Nome é obrigatório")
+    private String name;
+
+    @Min(0)
+    @Max(100)
+    private int progress;
+
+    @NotNull
+    private BigDecimal budget;
+
+    public Project() {
+    }
+
+    public Project(String name, int progress, BigDecimal budget) {
+        this.name = name;
+        updateProgress(progress);
+        this.budget = budget;
+    }
+
+    public void updateProgress(int newProgress) {
+        if (newProgress < 0 || newProgress > 100) {
+            throw new IllegalArgumentException("Progresso deve ser entre 0 e 100");
+        }
+        this.progress = newProgress;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
+
+    public BigDecimal getBudget() {
+        return budget;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Project project = (Project) o;
+        return Objects.equals(id, project.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectRepository.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectRepository.java
@@ -1,0 +1,14 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Query("SELECT new br.com.fiap.aguiabranca.domain.project.ProjectSummaryDto(" +
+            "COUNT(p), AVG(p.progress), SUM(p.budget)) FROM Project p")
+    ProjectSummaryDto summarize();
+
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectSummaryDto.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectSummaryDto.java
@@ -1,0 +1,9 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.math.BigDecimal;
+
+public record ProjectSummaryDto(
+        Long totalProjects,
+        Double avgProgress,
+        BigDecimal totalBudget) {
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/idea/IdeaTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/idea/IdeaTest.java
@@ -1,0 +1,38 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IdeaTest {
+
+    @Test
+    @DisplayName("Deve criar uma ideia com status inicial DRAFT")
+    void shouldCreateIdeaWithDraftStatus() {
+        Idea idea = new Idea("Sistema de Rotas", "Otimização de logística de frotas");
+
+        assertEquals("Sistema de Rotas", idea.getTitle());
+        assertEquals("Otimização de logística de frotas", idea.getDescription());
+        assertEquals(Idea.Status.DRAFT, idea.getStatus());
+    }
+
+    @Test
+    @DisplayName("Deve alterar o status ao revisar a ideia")
+    void shouldUpdateStatusOnReview() {
+        Idea idea = new Idea("Portal do Cliente", "Autoatendimento para clientes");
+        idea.review(Idea.Status.APPROVED);
+
+        assertEquals(Idea.Status.APPROVED, idea.getStatus());
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao tentar revisar para status DRAFT ou nulo")
+    void shouldThrowExceptionForInvalidReviewStatus() {
+        Idea idea = new Idea("Nova Frota", "Renovação de veículos");
+
+        assertThrows(IllegalArgumentException.class, () -> idea.review(null));
+        assertThrows(IllegalArgumentException.class, () -> idea.review(Idea.Status.DRAFT));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectRepositoryTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectRepositoryTest.java
@@ -1,0 +1,31 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+class ProjectRepositoryTest {
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Test
+    @DisplayName("Deve calcular corretamente a sumarizacao JPQL com tipos Long, Double e BigDecimal")
+    void shouldSummarizeProjectsWithCorrectTypes() {
+        projectRepository.save(new Project("Projeto A", 20, new BigDecimal("100000.00")));
+        projectRepository.save(new Project("Projeto B", 80, new BigDecimal("200000.00")));
+
+        ProjectSummaryDto summary = projectRepository.summarize();
+
+        assertNotNull(summary);
+        assertEquals(2L, summary.totalProjects());
+        assertEquals(50.0, summary.avgProgress());
+        assertEquals(new BigDecimal("300000.00"), summary.totalBudget());
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectRepositoryTestcontainersTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectRepositoryTestcontainersTest.java
@@ -1,0 +1,53 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnabledIf("isDockerAvailable")
+class ProjectRepositoryTestcontainersTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    static boolean isDockerAvailable() {
+        try {
+            return DockerClientFactory.instance().isDockerAvailable();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @Test
+    @DisplayName("Deve calcular corretamente a sumarizacao JPQL no PostgreSQL via Testcontainers")
+    void shouldSummarizeProjectsOnPostgres() {
+        projectRepository.save(new Project("Projeto A", 20, new BigDecimal("100000.00")));
+        projectRepository.save(new Project("Projeto B", 80, new BigDecimal("200000.00")));
+
+        ProjectSummaryDto summary = projectRepository.summarize();
+
+        assertNotNull(summary);
+        assertEquals(2L, summary.totalProjects());
+        assertEquals(50.0, summary.avgProgress());
+        assertEquals(new BigDecimal("300000.00"), summary.totalBudget());
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectTest.java
@@ -1,0 +1,33 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProjectTest {
+
+    @Test
+    @DisplayName("Deve criar projeto e atualizar progresso dentro do limite 0-100")
+    void shouldCreateProjectAndUpdateProgress() {
+        Project project = new Project("Hub de Inovação", 10, new BigDecimal("150000.00"));
+
+        assertEquals("Hub de Inovação", project.getName());
+        assertEquals(10, project.getProgress());
+        assertEquals(new BigDecimal("150000.00"), project.getBudget());
+
+        project.updateProgress(50);
+        assertEquals(50, project.getProgress());
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao atualizar progresso com valor menor que 0 ou maior que 100")
+    void shouldThrowExceptionForInvalidProgress() {
+        Project project = new Project("Hub de Inovação", 0, new BigDecimal("100000.00"));
+
+        assertThrows(IllegalArgumentException.class, () -> project.updateProgress(-1));
+        assertThrows(IllegalArgumentException.class, () -> project.updateProgress(101));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.flyway.enabled=false


### PR DESCRIPTION
## O que muda

Adicionadas dependências de Data JPA, Validation, Flyway, PostgreSQL, H2 e Testcontainers no [pom.xml](cci:7://file:///e:/PROJETOS%20DEV/FIAP-AGUIA-BRANCA/pom.xml:0:0-0:0), juntamente com `-Xlint:all` no `maven-compiler-plugin`. Estruturadas as entidades de domínio [Idea](cci:2://file:///e:/PROJETOS%20DEV/FIAP-AGUIA-BRANCA/src/main/java/br/com/fiap/aguiabranca/domain/idea/Idea.java:13:0-84:1) e [Project](cci:2://file:///e:/PROJETOS%20DEV/FIAP-AGUIA-BRANCA/src/main/java/br/com/fiap/aguiabranca/domain/project/Project.java:14:0-78:1), o DTO [ProjectSummaryDto](cci:2://file:///e:/PROJETOS%20DEV/FIAP-AGUIA-BRANCA/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectSummaryDto.java:4:0-8:1) e a consulta JPQL em [ProjectRepository](cci:2://file:///e:/PROJETOS%20DEV/FIAP-AGUIA-BRANCA/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectRepository.java:6:0-13:1), acompanhadas de suíte completa de testes.

Closes #2

## Como validar


<!-- Comandos que o revisor roda para confirmar. Ex.: ./mvnw -q verify -->

```bash
./mvnw -q verify

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer
- [x] Mudança de contrato de API está refletida no [README.md](cci:7://file:///e:/PROJETOS%20DEV/FIAP-AGUIA-BRANCA/README.md:0:0-0:0) / `api.http`
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta

## Risco

Risco baixo. Adição de infraestrutura inicial de persistência e validação sem impactos ou Breaking Changes em produção.
