### PR TITLE
chore(ci): workflow de build e testes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Um PR que recebe varios pushes seguidos nao precisa manter os builds antigos na fila.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # O nome "build" e o que a branch protection da #5 exige como status check.
+  # Renomear este job quebra a protecao da main silenciosamente.
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configura JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      # O runner ubuntu-latest ja traz Docker, entao o Testcontainers sobe o
+      # proprio Postgres. Nao use services: aqui — daria dois bancos no mesmo job.
+      - name: Build e testes
+        run: ./mvnw -B verify
+
+      - name: Publica relatorio de testes
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: relatorio-testes
+          path: |
+            target/surefire-reports/
+            target/failsafe-reports/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
 
 	<properties>
 		<java.version>21</java.version>
+		<!-- O Testcontainers gerenciado pelo Boot 3.3.5 (1.19.8) fixa a API Docker 1.32
+		     internamente, e o Docker Engine >= 29 recusa: "client version 1.32 is too old.
+		     Minimum supported API version is 1.40". Com 1.19.8 o teste nao falha — ele e
+		     PULADO pelo @EnabledIf, o que fazia o build passar verde sem ter rodado. -->
+		<testcontainers.version>1.21.4</testcontainers.version>
 	</properties>
 
 	<dependencies>

--- a/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectRepositoryTestcontainersTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/project/ProjectRepositoryTestcontainersTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -19,6 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @DataJpaTest
 @Testcontainers
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// Em banco nao-embarcado o ddl-auto default e "none": sem isto o Hibernate nao cria nada e o
+// teste morre com relation "projects" does not exist. O slice valida a expressao JPQL no
+// dialeto do Postgres, nao o schema — por isso gera o schema pelas entidades, sem Flyway.
+@TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 @EnabledIf("isDockerAvailable")
 class ProjectRepositoryTestcontainersTest {
 


### PR DESCRIPTION
## O que muda

Adiciona `.github/workflows/ci.yml`: job `build` em `ubuntu-latest`, JDK 21 temurin com cache Maven,
rodando `./mvnw -B verify` em todo PR e em push na `main`.

Junto vem a correção sem a qual o critério "os testes com Testcontainers passam no runner" seria
falso: **o teste de Testcontainers nunca rodou**. O `@EnabledIf("isDockerAvailable")` o pulava
silenciosamente e o build fechava verde com `Skipped: 1`. Duas causas empilhadas:

1. O Testcontainers gerenciado pelo Boot 3.3.5 (1.19.8) fixa a API Docker `1.32` internamente, e
   o Docker Engine >= 29 recusa: `client version 1.32 is too old. Minimum supported API version is 1.40`.
   → subido para `1.21.4` via property.
2. Com o Docker enfim detectado, o teste quebrava em `relation "projects" does not exist`: Flyway
   está desligado nos testes e `ddl-auto` default é `none` em banco não-embarcado.
   → `ddl-auto=create-drop` via `@TestPropertySource` no próprio teste.

O slice existe para validar a expressão JPQL no dialeto do Postgres, não o schema — por isso gera
as tabelas pelas entidades em vez de rodar migration.

Closes #3

## Como validar

```
./mvnw -B verify
```

Antes: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 1`
Depois: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`

O `Skipped: 0` é o ponto — é a prova de que o container de Postgres subiu de verdade.
No CI, `gh pr checks` mostra o job com nome `build`, que é o que a #5 vai exigir na branch protection.

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer — n/a
- [x] Mudança de contrato de API está refletida no `README.md` / `api.http` — n/a
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta — n/a

## Risco

O bump do Testcontainers é o único ponto de atenção: sobe de 1.19.8 para 1.21.4 por cima do que o
Boot gerencia. Em compensação, é o que faz o teste existir de fato — mantê-lo em 1.19.8 significa
CI verde que não testa nada em máquina com Docker moderno.

`concurrency` com `cancel-in-progress` cancela builds redundantes do mesmo PR: se dois pushes
saírem juntos, só o último reporta.
