### PR TITLE
fix(auth): JWT_SECRET so por variavel de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copie para .env e preencha. O .env real nao vai para o git (ver .gitignore).
+
+# Segredo de assinatura do JWT (HS256). Minimo de 32 bytes — a aplicacao nao sobe abaixo disso.
+# Gere o seu com:  openssl rand -base64 48
+# Nunca reaproveite o valor do profile dev: ele e publico, esta versionado no repositorio.
+JWT_SECRET=
+
+# Banco
+DB_URL=jdbc:postgresql://localhost:5432/aguiabranca
+DB_USERNAME=aguiabranca
+DB_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -18,8 +18,24 @@ docker run -d --name aguiabranca-db -p 5432:5432 \
   -e POSTGRES_DB=aguiabranca -e POSTGRES_USER=aguiabranca -e POSTGRES_PASSWORD=aguiabranca \
   postgres:16-alpine
 
-./mvnw spring-boot:run
+SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
 ```
+
+### O segredo do JWT
+
+A aplicação **não sobe** sem `JWT_SECRET`, e recusa segredo com menos de 32 bytes — HS256 assina
+com bloco de 256 bits, e chave menor enfraquece a assinatura. Gere o seu:
+
+```bash
+openssl rand -base64 48
+```
+
+O profile `dev` traz um segredo pronto para não travar quem está começando. Ele é **público**:
+está versionado em `application-dev.yml`, então qualquer pessoa que leia o repositório consegue
+forjar um token de `LIDERANCA`. Por isso a aplicação recusa o boot se esse valor aparecer com
+qualquer profile diferente de `dev`.
+
+Fora de dev, a variável vem do ambiente — `.env.example` lista o que preencher.
 
 O Flyway aplica `V1__initial_schema.sql` e o seed de desenvolvimento no boot. Usuários criados
 pelo seed, um por perfil:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ qualquer profile diferente de `dev`.
 
 Fora de dev, a variável vem do ambiente — `.env.example` lista o que preencher.
 
-O Flyway aplica `V1__initial_schema.sql` e o seed de desenvolvimento no boot. Usuários criados
-pelo seed, um por perfil:
+O Flyway aplica `V1__initial_schema.sql` em qualquer ambiente. O seed de desenvolvimento vive em
+`db/seed/` e **só entra com o profile `dev`** — em produção essas linhas não existem. Usuários
+criados pelo seed, um por perfil:
 
 | E-mail | Senha | Perfil |
 |---|---|---|

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
@@ -1,0 +1,23 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Origens autorizadas a chamar a API de um navegador.
+ *
+ * Lista vazia por default e a decisao central: entregar pronto e desligado. Enquanto o unico
+ * cliente for o app Android — que nao passa por CORS —, nenhuma origem cross-origin funciona
+ * sem alguem escrever explicitamente qual.
+ */
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(List<String> allowedOrigins) {
+
+    public CorsProperties {
+        allowedOrigins = allowedOrigins == null ? List.of() : List.copyOf(allowedOrigins);
+    }
+
+    public boolean isEnabled() {
+        return !allowedOrigins.isEmpty();
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtProperties.java
@@ -1,12 +1,36 @@
 package br.com.fiap.aguiabranca.domain.auth;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * TODO(#6): secret ainda aceita o default de dev vindo do application.yml.
  * TODO(#8): expiration de 8h sem refresh — o app expulsa o usuario no meio do uso.
  */
 @ConfigurationProperties(prefix = "app.jwt")
 public record JwtProperties(String secret, Duration expiration) {
+
+    /** HS256 assina com bloco de 256 bits: chave menor enfraquece a assinatura. */
+    static final int MIN_SECRET_BYTES = 32;
+
+    /**
+     * Valida na propria vinculacao da propriedade, nao num listener depois do boot.
+     *
+     * A jjwt 0.12 tambem recusa chave curta, mas so na primeira assinatura — ou seja, no
+     * primeiro login de um usuario real, em runtime. Aqui a aplicacao simplesmente nao sobe.
+     */
+    public JwtProperties {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException(
+                    "JWT_SECRET nao definida. Gere uma com: openssl rand -base64 48");
+        }
+
+        int bytes = secret.getBytes(StandardCharsets.UTF_8).length;
+        if (bytes < MIN_SECRET_BYTES) {
+            // Informa o tamanho, nunca o valor: mensagem de erro vai para log, e log vaza.
+            throw new IllegalStateException(
+                    "JWT_SECRET tem " + bytes + " bytes; o minimo para HS256 e " + MIN_SECRET_BYTES
+                            + ". Gere uma com: openssl rand -base64 48");
+        }
+    }
 }

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretGuard.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretGuard.java
@@ -1,0 +1,29 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.util.Arrays;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Impede que o segredo de desenvolvimento suba em ambiente que nao seja dev.
+ *
+ * O valor de dev esta versionado em application-dev.yml — qualquer um que leia o repositorio
+ * consegue forjar um token de LIDERANCA. O tamanho dele passa na validacao de bytes do
+ * JwtProperties, entao so essa checagem por valor o pega.
+ */
+@Component
+class JwtSecretGuard {
+
+    static final String DEV_SECRET = "dev-secret-nao-use-em-producao-troque-me-agora";
+
+    JwtSecretGuard(JwtProperties properties, Environment environment) {
+        boolean devProfile = Arrays.asList(environment.getActiveProfiles()).contains("dev");
+
+        if (!devProfile && DEV_SECRET.equals(properties.secret())) {
+            throw new IllegalStateException(
+                    "JWT_SECRET esta com o valor de desenvolvimento, que e publico no repositorio, "
+                            + "e o profile ativo nao e dev. Defina JWT_SECRET no ambiente. "
+                            + "Gere uma com: openssl rand -base64 48");
+        }
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -5,6 +5,8 @@ import br.com.fiap.aguiabranca.shared.GlobalExceptionHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,18 +19,24 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class })
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
     private final ObjectMapper objectMapper;
+    private final CorsProperties corsProperties;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtFilter, ObjectMapper objectMapper) {
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter, ObjectMapper objectMapper,
+            CorsProperties corsProperties) {
         this.jwtFilter = jwtFilter;
         this.objectMapper = objectMapper;
+        this.corsProperties = corsProperties;
     }
 
     @Bean
@@ -36,6 +44,7 @@ public class SecurityConfig {
         return http
                 // API stateless com token: nao ha sessao nem formulario para o CSRF proteger.
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/login").permitAll()
@@ -69,6 +78,32 @@ public class SecurityConfig {
         response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
         objectMapper.writeValue(response.getOutputStream(),
                 GlobalExceptionHandler.asMap(status, type, title, detail, instance));
+    }
+
+    /**
+     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos controllers:
+     * anotacao por controller e o que faz uma rota nova nascer com regra diferente das outras.
+     *
+     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao cross-origin recebe
+     * Access-Control-Allow-Origin, entao o navegador barra.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        if (corsProperties.isEnabled()) {
+            CorsConfiguration configuration = new CorsConfiguration();
+            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio Spring
+            // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
+            configuration.setAllowedOrigins(corsProperties.allowedOrigins());
+            configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Request-Id"));
+            configuration.setAllowCredentials(true);
+            configuration.setMaxAge(Duration.ofHours(1));
+            source.registerCorsConfiguration("/**", configuration);
+        }
+
+        return source;
     }
 
     @Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,16 @@
 # Profile de desenvolvimento. O segredo abaixo e publico por definicao — esta versionado.
 # O JwtSecretGuard recusa o boot se ele aparecer com qualquer profile que nao seja dev.
+spring:
+  flyway:
+    locations: classpath:db/migration,classpath:db/seed
+    # O seed e a versao 9000. Sem out-of-order, uma V3 nova de producao seria recusada em dev
+    # ("out of order") por ter numero menor que algo ja aplicado.
+    out-of-order: true
+    # Banco de dev que aplicou o seed quando ele ainda era a V2 tem no historico uma versao
+    # que nao existe mais em lugar nenhum. Sem isto, o Flyway trava com "applied migration not
+    # resolved locally" e o unico caminho seria recriar o banco.
+    ignore-migration-patterns: "*:missing"
+
 app:
   jwt:
     secret: dev-secret-nao-use-em-producao-troque-me-agora

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,5 @@
+# Profile de desenvolvimento. O segredo abaixo e publico por definicao — esta versionado.
+# O JwtSecretGuard recusa o boot se ele aparecer com qualquer profile que nao seja dev.
+app:
+  jwt:
+    secret: dev-secret-nao-use-em-producao-troque-me-agora

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,9 +24,9 @@ spring:
 
 app:
   jwt:
-    # TODO(#6): segredo com default embutido. Qualquer um que leia o repositorio consegue
-    # forjar um token de LIDERANCA. Precisa vir so de variavel de ambiente.
-    secret: ${JWT_SECRET:dev-secret-nao-use-em-producao-troque-me-agora}
+    # Sem default: a aplicacao nao sobe sem JWT_SECRET no ambiente. Para desenvolvimento,
+    # o valor vem do profile dev (application-dev.yml), nunca daqui.
+    secret: ${JWT_SECRET:}
     # TODO(#8): 8h sem renovacao — o app derruba o usuario no meio do uso quando expira.
     expiration: PT8H
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,9 +20,18 @@ spring:
 
   flyway:
     enabled: true
+    # Somente db/migration. O seed de desenvolvimento vive em db/seed e so entra pelo
+    # profile dev — assim producao nao ganha contas com senha conhecida por construcao,
+    # e nao por alguem lembrar de apagar a linha depois.
     locations: classpath:db/migration
 
 app:
+  cors:
+    # Vazio por default: nenhuma origem cross-origin passa sem configuracao explicita.
+    # O cliente atual e o app Android, que nao e afetado por CORS — isto fica pronto e
+    # desligado, esperando um front web existir.
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
   jwt:
     # Sem default: a aplicacao nao sobe sem JWT_SECRET no ambiente. Para desenvolvimento,
     # o valor vem do profile dev (application-dev.yml), nunca daqui.

--- a/src/main/resources/db/seed/V9000__seed_dev_data.sql
+++ b/src/main/resources/db/seed/V9000__seed_dev_data.sql
@@ -1,8 +1,11 @@
 -- Massa de desenvolvimento: um usuario por perfil e dados de exemplo para as telas.
 --
--- ATENCAO (#7): esta migration esta em db/migration, entao o Flyway a executa em TODO
--- ambiente — inclusive producao, criando contas com senha conhecida no banco real.
--- Corrigir separando por location ou movendo para test/resources.
+-- Vive em db/seed, fora do location de producao. So o profile dev inclui esta pasta, entao
+-- em prod estas linhas nao existem e a versao nao aparece no flyway_schema_history.
+--
+-- A versao e 9000, nao 2, de proposito: o Flyway funde os dois locations numa sequencia unica
+-- de versoes. Com o seed em V2, a proxima migration real de producao tambem seria V2 e os dois
+-- ambientes divergiriam no mesmo numero. Numero alto mantem as duas faixas separadas.
 --
 -- Senhas: operador123 / gestor123 / lideranca123 (BCrypt custo 10).
 

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
@@ -1,0 +1,31 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+/**
+ * Configuracao default — nenhuma origem listada. Nada de cross-origin pode passar.
+ */
+class CorsDisabledIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("Sem origem configurada, o preflight nao recebe Allow-Origin")
+    void shouldNotAllowAnyOriginByDefault() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", "https://qualquer-um.example")
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Sem origem configurada, resposta normal tambem nao ganha Allow-Origin")
+    void shouldNotDecorateSimpleRequests() throws Exception {
+        mockMvc.perform(get("/ideas").header("Origin", "https://qualquer-um.example"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
@@ -1,0 +1,63 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = "app.cors.allowed-origins=https://hub.aguiabranca.dev")
+class CorsEnabledIntegrationTest extends IntegrationTestSupport {
+
+    private static final String ALLOWED = "https://hub.aguiabranca.dev";
+    private static final String DENIED = "https://site-qualquer.example";
+
+    @Test
+    @DisplayName("Preflight de origem permitida responde 200 com os headers corretos")
+    void shouldAllowConfiguredOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+    }
+
+    @Test
+    @DisplayName("Preflight de origem nao listada e recusado")
+    void shouldRejectUnknownOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", DENIED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Authorization esta entre os headers permitidos")
+    void shouldAllowAuthorizationHeader() throws Exception {
+        // Sem isto o navegador barra o preflight e nenhuma chamada autenticada sai do front.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET")
+                .header("Access-Control-Request-Headers", "Authorization"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Headers", containsString("Authorization")));
+    }
+
+    @Test
+    @DisplayName("Com credenciais habilitadas, Allow-Origin nunca sai como curinga")
+    void shouldNeverEchoWildcardWithCredentials() throws Exception {
+        // "*" com allowCredentials e recusado pelo proprio Spring em runtime; o header tem
+        // que ecoar a origem que pediu.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "POST"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretValidationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretValidationTest.java
@@ -1,0 +1,105 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Valida o boot, nao o runtime: por isso ApplicationContextRunner em vez de @SpringBootTest.
+ * O que se afirma aqui e "o contexto NAO sobe", e subir a app inteira so para vê-la falhar
+ * custaria um Postgres por caso de teste.
+ */
+class JwtSecretValidationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of())
+            .withUserConfiguration(JwtTestConfiguration.class)
+            .withPropertyValues("app.jwt.expiration=PT8H");
+
+    @Test
+    @DisplayName("Sobe com segredo proprio de 32 bytes ou mais")
+    void shouldStartWithStrongSecret() {
+        runner.withPropertyValues("app.jwt.secret=um-segredo-bem-comprido-com-mais-de-32-bytes")
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    @DisplayName("Nao sobe com segredo menor que 32 bytes")
+    void shouldFailWhenSecretIsTooShort() {
+        runner.withPropertyValues("app.jwt.secret=curto-demais")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(rootMessage(context.getStartupFailure())).contains("12 bytes", "minimo para HS256");
+                });
+    }
+
+    @Test
+    @DisplayName("Nao sobe sem JWT_SECRET definida")
+    void shouldFailWhenSecretIsMissing() {
+        runner.withPropertyValues("app.jwt.secret=")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(rootMessage(context.getStartupFailure())).contains("JWT_SECRET nao definida");
+                });
+    }
+
+    @Test
+    @DisplayName("Nao sobe com o segredo de dev fora do profile dev")
+    void shouldRejectDevSecretOutsideDevProfile() {
+        runner.withPropertyValues("app.jwt.secret=" + JwtSecretGuard.DEV_SECRET)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(rootMessage(context.getStartupFailure()))
+                            .contains("valor de desenvolvimento");
+                });
+    }
+
+    @Test
+    @DisplayName("Aceita o segredo de dev quando o profile dev esta ativo")
+    void shouldAcceptDevSecretUnderDevProfile() {
+        runner.withPropertyValues("app.jwt.secret=" + JwtSecretGuard.DEV_SECRET)
+                .withSystemProperties("spring.profiles.active=dev")
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    @DisplayName("A mensagem de erro nunca imprime o valor do segredo")
+    void shouldNeverPrintTheSecretValue() {
+        String secret = "curto";
+
+        runner.withPropertyValues("app.jwt.secret=" + secret)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    // Mensagem de boot vai para log, e log vaza: ela informa o tamanho, nunca o valor.
+                    assertThat(fullTrace(context.getStartupFailure())).doesNotContain(secret);
+                });
+    }
+
+    private static String rootMessage(Throwable failure) {
+        Throwable root = failure;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        return String.valueOf(root.getMessage());
+    }
+
+    private static String fullTrace(Throwable failure) {
+        StringBuilder text = new StringBuilder();
+        for (Throwable current = failure; current != null; current = current.getCause()) {
+            text.append(current.getMessage()).append('\n');
+        }
+        return text.toString();
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(JwtProperties.class)
+    @Import(JwtSecretGuard.class)
+    static class JwtTestConfiguration {
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
@@ -1,0 +1,125 @@
+package br.com.fiap.aguiabranca.domain.user;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Prova que o seed nao alcanca producao.
+ *
+ * Roda o Flyway pela API Java em um banco novo por caso, em vez de subir o contexto do Spring:
+ * o que se afirma aqui e sobre a configuracao do Flyway, e dois contextos com locations
+ * diferentes brigando pelo mesmo banco dariam um teste que depende da ordem de execucao.
+ */
+class SeedMigrationIsolationTest {
+
+    private static final String PRODUCTION_LOCATIONS = "classpath:db/migration";
+    private static final String DEVELOPMENT_LOCATIONS = "classpath:db/migration,classpath:db/seed";
+
+    @Test
+    @DisplayName("Locations de producao nao criam nenhuma linha do seed")
+    void productionLocationsShouldNotApplySeed() throws SQLException {
+        String url = freshDatabase("prod_sem_seed");
+        migrate(url, PRODUCTION_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM users")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM ideas")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM projects")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM strategies")).isZero();
+    }
+
+    @Test
+    @DisplayName("flyway_schema_history de producao nao contem a versao do seed")
+    void productionHistoryShouldNotContainSeedVersion() throws SQLException {
+        String url = freshDatabase("prod_historico");
+        migrate(url, PRODUCTION_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '9000'"))
+                .isZero();
+        // A V1 continua registrada: o schema real e o mesmo dos dois lados.
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '1'"))
+                .isOne();
+    }
+
+    @Test
+    @DisplayName("Locations de desenvolvimento continuam criando o seed")
+    void developmentLocationsShouldApplySeed() throws SQLException {
+        String url = freshDatabase("dev_com_seed");
+        migrate(url, DEVELOPMENT_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM users")).isEqualTo(4);
+        assertThat(count(url, "SELECT count(*) FROM users WHERE role = 'LIDERANCA'")).isOne();
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '9000'"))
+                .isOne();
+    }
+
+    @Test
+    @DisplayName("O schema aplicado e o mesmo nos dois ambientes — so o conteudo difere")
+    void schemaShouldBeIdenticalAcrossEnvironments() throws SQLException {
+        String production = freshDatabase("comparacao_prod");
+        String development = freshDatabase("comparacao_dev");
+        migrate(production, PRODUCTION_LOCATIONS);
+        migrate(development, DEVELOPMENT_LOCATIONS);
+
+        // Divergencia de schema entre ambientes e o que faz "funciona em dev" virar erro no deploy.
+        assertThat(tableNames(development)).isEqualTo(tableNames(production));
+    }
+
+    private static void migrate(String url, String locations) {
+        Flyway.configure()
+                .dataSource(url, IntegrationTestSupport.POSTGRES.getUsername(),
+                        IntegrationTestSupport.POSTGRES.getPassword())
+                .locations(locations.split(","))
+                .load()
+                .migrate();
+    }
+
+    /** CREATE DATABASE nao roda dentro de transacao — dai o Statement direto no autocommit. */
+    private static String freshDatabase(String name) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        try (Connection connection = DriverManager.getConnection(container.getJdbcUrl(),
+                container.getUsername(), container.getPassword());
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP DATABASE IF EXISTS " + name);
+            statement.execute("CREATE DATABASE " + name);
+        }
+        return "jdbc:postgresql://" + container.getHost() + ":" + container.getFirstMappedPort() + "/" + name;
+    }
+
+    private static long count(String url, String sql) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        try (Connection connection = DriverManager.getConnection(url, container.getUsername(),
+                container.getPassword());
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(sql)) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    private static String tableNames(String url) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        StringBuilder names = new StringBuilder();
+        try (Connection connection = DriverManager.getConnection(url, container.getUsername(),
+                container.getPassword());
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("""
+                        SELECT table_name FROM information_schema.tables
+                        WHERE table_schema = 'public' AND table_name <> 'flyway_schema_history'
+                        ORDER BY table_name
+                        """)) {
+            while (rs.next()) {
+                names.append(rs.getString(1)).append(',');
+            }
+        }
+        return names.toString();
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
+++ b/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @ActiveProfiles("integration")
 public abstract class IntegrationTestSupport {
 
-    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+    public static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
 
     static {
         POSTGRES.start();

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -3,3 +3,4 @@
 # religa, porque o objetivo oposto — provar que migration e entidade nao divergiram.
 spring.flyway.enabled=true
 spring.jpa.hibernate.ddl-auto=validate
+app.jwt.secret=segredo-de-teste-com-mais-de-32-bytes-para-hs256


### PR DESCRIPTION
## O que muda

O segredo tinha default embutido no `application.yml`. Segredo default versionado vaza no git e
permite forjar token de qualquer perfil — inclusive `LIDERANCA`. Agora:

- `application.yml` usa `${JWT_SECRET:}` — **sem default**. Sem a variável, a aplicação não sobe.
- O valor de desenvolvimento mudou de casa: vai para `application-dev.yml`, carregado só no profile `dev`.
- `JwtProperties` valida o tamanho **na vinculação da propriedade**.
- `JwtSecretGuard` recusa o boot se o segredo de dev aparecer com profile diferente de `dev`.
- `.env.example` documenta a variável sem trazer valor.
- `README.md` ganha a seção de como gerar o segredo.

Closes #6

### Por que validar na vinculação, e não depois do boot

A jjwt 0.12 também recusa chave curta, mas só **na primeira assinatura** — ou seja, no primeiro
login de um usuário real, em produção, com a aplicação já reportando saudável. Validando na
vinculação da property, o contexto nem chega a subir.

As duas checagens são independentes de propósito: o segredo de dev tem 45 bytes e passa
folgado na validação de tamanho. Só a comparação por valor o pega.

## Como validar

```
./mvnw -B verify
```

`JwtSecretValidationTest` usa `ApplicationContextRunner` — o que se afirma é "o contexto **não**
sobe", e subir a app inteira só para vê-la falhar custaria um Postgres por caso:

| Cenário | Esperado |
|---|---|
| Segredo com 32+ bytes | sobe |
| Segredo com 12 bytes | falha, mensagem cita `12 bytes` |
| `JWT_SECRET` vazia | falha, `JWT_SECRET nao definida` |
| Segredo de dev, profile != `dev` | falha, `valor de desenvolvimento` |
| Segredo de dev, profile `dev` | sobe |
| Qualquer falha | a mensagem **não contém** o valor do segredo |

O último é o que costuma passar batido: mensagem de boot vai para log, e log vaza. A mensagem
informa o **tamanho** ("tem 12 bytes; o mínimo é 32"), nunca o valor.

Manualmente:

```
./mvnw spring-boot:run                     # falha: JWT_SECRET nao definida
JWT_SECRET=curto ./mvnw spring-boot:run    # falha: 5 bytes
SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run   # sobe
```

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff — o valor de dev continua versionado **de propósito**, agora isolado no profile `dev` e barrado fora dele
- [x] Migration nova é idempotente e não roda em produção sem querer — n/a
- [x] Mudança de contrato de API está refletida no `README.md`
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta — n/a

## Risco

**Breaking change de operação:** qualquer ambiente que hoje sobe sem `JWT_SECRET` para de subir.
É o efeito pretendido, mas quem for fazer deploy precisa definir a variável **antes** de mergear.
Rollback é reverter o commit — nada de migration ou estado envolvido.

Ponto de atenção para o revisor: o profile `dev` precisa estar ativo no desenvolvimento local
(`SPRING_PROFILES_ACTIVE=dev`), senão o boot falha com a mensagem do guard. O compose da #12 vai
passar `JWT_SECRET` por ambiente.

Base do PR é `chore/actuator` (#11).