### PR TITLE
fix(banco): tira o seed de desenvolvimento do caminho de producao

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ qualquer profile diferente de `dev`.
 
 Fora de dev, a variável vem do ambiente — `.env.example` lista o que preencher.
 
-O Flyway aplica `V1__initial_schema.sql` e o seed de desenvolvimento no boot. Usuários criados
-pelo seed, um por perfil:
+O Flyway aplica `V1__initial_schema.sql` em qualquer ambiente. O seed de desenvolvimento vive em
+`db/seed/` e **só entra com o profile `dev`** — em produção essas linhas não existem. Usuários
+criados pelo seed, um por perfil:
 
 | E-mail | Senha | Perfil |
 |---|---|---|

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
@@ -1,0 +1,23 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Origens autorizadas a chamar a API de um navegador.
+ *
+ * Lista vazia por default e a decisao central: entregar pronto e desligado. Enquanto o unico
+ * cliente for o app Android — que nao passa por CORS —, nenhuma origem cross-origin funciona
+ * sem alguem escrever explicitamente qual.
+ */
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(List<String> allowedOrigins) {
+
+    public CorsProperties {
+        allowedOrigins = allowedOrigins == null ? List.of() : List.copyOf(allowedOrigins);
+    }
+
+    public boolean isEnabled() {
+        return !allowedOrigins.isEmpty();
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -5,6 +5,8 @@ import br.com.fiap.aguiabranca.shared.GlobalExceptionHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,18 +19,24 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class })
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
     private final ObjectMapper objectMapper;
+    private final CorsProperties corsProperties;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtFilter, ObjectMapper objectMapper) {
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter, ObjectMapper objectMapper,
+            CorsProperties corsProperties) {
         this.jwtFilter = jwtFilter;
         this.objectMapper = objectMapper;
+        this.corsProperties = corsProperties;
     }
 
     @Bean
@@ -36,6 +44,7 @@ public class SecurityConfig {
         return http
                 // API stateless com token: nao ha sessao nem formulario para o CSRF proteger.
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/login").permitAll()
@@ -69,6 +78,32 @@ public class SecurityConfig {
         response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
         objectMapper.writeValue(response.getOutputStream(),
                 GlobalExceptionHandler.asMap(status, type, title, detail, instance));
+    }
+
+    /**
+     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos controllers:
+     * anotacao por controller e o que faz uma rota nova nascer com regra diferente das outras.
+     *
+     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao cross-origin recebe
+     * Access-Control-Allow-Origin, entao o navegador barra.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        if (corsProperties.isEnabled()) {
+            CorsConfiguration configuration = new CorsConfiguration();
+            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio Spring
+            // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
+            configuration.setAllowedOrigins(corsProperties.allowedOrigins());
+            configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Request-Id"));
+            configuration.setAllowCredentials(true);
+            configuration.setMaxAge(Duration.ofHours(1));
+            source.registerCorsConfiguration("/**", configuration);
+        }
+
+        return source;
     }
 
     @Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,16 @@
 # Profile de desenvolvimento. O segredo abaixo e publico por definicao — esta versionado.
 # O JwtSecretGuard recusa o boot se ele aparecer com qualquer profile que nao seja dev.
+spring:
+  flyway:
+    locations: classpath:db/migration,classpath:db/seed
+    # O seed e a versao 9000. Sem out-of-order, uma V3 nova de producao seria recusada em dev
+    # ("out of order") por ter numero menor que algo ja aplicado.
+    out-of-order: true
+    # Banco de dev que aplicou o seed quando ele ainda era a V2 tem no historico uma versao
+    # que nao existe mais em lugar nenhum. Sem isto, o Flyway trava com "applied migration not
+    # resolved locally" e o unico caminho seria recriar o banco.
+    ignore-migration-patterns: "*:missing"
+
 app:
   jwt:
     secret: dev-secret-nao-use-em-producao-troque-me-agora

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,12 @@ spring:
     locations: classpath:db/migration
 
 app:
+  cors:
+    # Vazio por default: nenhuma origem cross-origin passa sem configuracao explicita.
+    # O cliente atual e o app Android, que nao e afetado por CORS — isto fica pronto e
+    # desligado, esperando um front web existir.
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
   jwt:
     # Sem default: a aplicacao nao sobe sem JWT_SECRET no ambiente. Para desenvolvimento,
     # o valor vem do profile dev (application-dev.yml), nunca daqui.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,9 @@ spring:
 
   flyway:
     enabled: true
+    # Somente db/migration. O seed de desenvolvimento vive em db/seed e so entra pelo
+    # profile dev — assim producao nao ganha contas com senha conhecida por construcao,
+    # e nao por alguem lembrar de apagar a linha depois.
     locations: classpath:db/migration
 
 app:

--- a/src/main/resources/db/seed/V9000__seed_dev_data.sql
+++ b/src/main/resources/db/seed/V9000__seed_dev_data.sql
@@ -1,8 +1,11 @@
 -- Massa de desenvolvimento: um usuario por perfil e dados de exemplo para as telas.
 --
--- ATENCAO (#7): esta migration esta em db/migration, entao o Flyway a executa em TODO
--- ambiente — inclusive producao, criando contas com senha conhecida no banco real.
--- Corrigir separando por location ou movendo para test/resources.
+-- Vive em db/seed, fora do location de producao. So o profile dev inclui esta pasta, entao
+-- em prod estas linhas nao existem e a versao nao aparece no flyway_schema_history.
+--
+-- A versao e 9000, nao 2, de proposito: o Flyway funde os dois locations numa sequencia unica
+-- de versoes. Com o seed em V2, a proxima migration real de producao tambem seria V2 e os dois
+-- ambientes divergiriam no mesmo numero. Numero alto mantem as duas faixas separadas.
 --
 -- Senhas: operador123 / gestor123 / lideranca123 (BCrypt custo 10).
 

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
@@ -1,0 +1,31 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+/**
+ * Configuracao default — nenhuma origem listada. Nada de cross-origin pode passar.
+ */
+class CorsDisabledIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("Sem origem configurada, o preflight nao recebe Allow-Origin")
+    void shouldNotAllowAnyOriginByDefault() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", "https://qualquer-um.example")
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Sem origem configurada, resposta normal tambem nao ganha Allow-Origin")
+    void shouldNotDecorateSimpleRequests() throws Exception {
+        mockMvc.perform(get("/ideas").header("Origin", "https://qualquer-um.example"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
@@ -1,0 +1,63 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = "app.cors.allowed-origins=https://hub.aguiabranca.dev")
+class CorsEnabledIntegrationTest extends IntegrationTestSupport {
+
+    private static final String ALLOWED = "https://hub.aguiabranca.dev";
+    private static final String DENIED = "https://site-qualquer.example";
+
+    @Test
+    @DisplayName("Preflight de origem permitida responde 200 com os headers corretos")
+    void shouldAllowConfiguredOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+    }
+
+    @Test
+    @DisplayName("Preflight de origem nao listada e recusado")
+    void shouldRejectUnknownOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", DENIED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Authorization esta entre os headers permitidos")
+    void shouldAllowAuthorizationHeader() throws Exception {
+        // Sem isto o navegador barra o preflight e nenhuma chamada autenticada sai do front.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET")
+                .header("Access-Control-Request-Headers", "Authorization"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Headers", containsString("Authorization")));
+    }
+
+    @Test
+    @DisplayName("Com credenciais habilitadas, Allow-Origin nunca sai como curinga")
+    void shouldNeverEchoWildcardWithCredentials() throws Exception {
+        // "*" com allowCredentials e recusado pelo proprio Spring em runtime; o header tem
+        // que ecoar a origem que pediu.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "POST"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
@@ -1,0 +1,125 @@
+package br.com.fiap.aguiabranca.domain.user;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Prova que o seed nao alcanca producao.
+ *
+ * Roda o Flyway pela API Java em um banco novo por caso, em vez de subir o contexto do Spring:
+ * o que se afirma aqui e sobre a configuracao do Flyway, e dois contextos com locations
+ * diferentes brigando pelo mesmo banco dariam um teste que depende da ordem de execucao.
+ */
+class SeedMigrationIsolationTest {
+
+    private static final String PRODUCTION_LOCATIONS = "classpath:db/migration";
+    private static final String DEVELOPMENT_LOCATIONS = "classpath:db/migration,classpath:db/seed";
+
+    @Test
+    @DisplayName("Locations de producao nao criam nenhuma linha do seed")
+    void productionLocationsShouldNotApplySeed() throws SQLException {
+        String url = freshDatabase("prod_sem_seed");
+        migrate(url, PRODUCTION_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM users")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM ideas")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM projects")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM strategies")).isZero();
+    }
+
+    @Test
+    @DisplayName("flyway_schema_history de producao nao contem a versao do seed")
+    void productionHistoryShouldNotContainSeedVersion() throws SQLException {
+        String url = freshDatabase("prod_historico");
+        migrate(url, PRODUCTION_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '9000'"))
+                .isZero();
+        // A V1 continua registrada: o schema real e o mesmo dos dois lados.
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '1'"))
+                .isOne();
+    }
+
+    @Test
+    @DisplayName("Locations de desenvolvimento continuam criando o seed")
+    void developmentLocationsShouldApplySeed() throws SQLException {
+        String url = freshDatabase("dev_com_seed");
+        migrate(url, DEVELOPMENT_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM users")).isEqualTo(4);
+        assertThat(count(url, "SELECT count(*) FROM users WHERE role = 'LIDERANCA'")).isOne();
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '9000'"))
+                .isOne();
+    }
+
+    @Test
+    @DisplayName("O schema aplicado e o mesmo nos dois ambientes — so o conteudo difere")
+    void schemaShouldBeIdenticalAcrossEnvironments() throws SQLException {
+        String production = freshDatabase("comparacao_prod");
+        String development = freshDatabase("comparacao_dev");
+        migrate(production, PRODUCTION_LOCATIONS);
+        migrate(development, DEVELOPMENT_LOCATIONS);
+
+        // Divergencia de schema entre ambientes e o que faz "funciona em dev" virar erro no deploy.
+        assertThat(tableNames(development)).isEqualTo(tableNames(production));
+    }
+
+    private static void migrate(String url, String locations) {
+        Flyway.configure()
+                .dataSource(url, IntegrationTestSupport.POSTGRES.getUsername(),
+                        IntegrationTestSupport.POSTGRES.getPassword())
+                .locations(locations.split(","))
+                .load()
+                .migrate();
+    }
+
+    /** CREATE DATABASE nao roda dentro de transacao — dai o Statement direto no autocommit. */
+    private static String freshDatabase(String name) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        try (Connection connection = DriverManager.getConnection(container.getJdbcUrl(),
+                container.getUsername(), container.getPassword());
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP DATABASE IF EXISTS " + name);
+            statement.execute("CREATE DATABASE " + name);
+        }
+        return "jdbc:postgresql://" + container.getHost() + ":" + container.getFirstMappedPort() + "/" + name;
+    }
+
+    private static long count(String url, String sql) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        try (Connection connection = DriverManager.getConnection(url, container.getUsername(),
+                container.getPassword());
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(sql)) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    private static String tableNames(String url) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        StringBuilder names = new StringBuilder();
+        try (Connection connection = DriverManager.getConnection(url, container.getUsername(),
+                container.getPassword());
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("""
+                        SELECT table_name FROM information_schema.tables
+                        WHERE table_schema = 'public' AND table_name <> 'flyway_schema_history'
+                        ORDER BY table_name
+                        """)) {
+            while (rs.next()) {
+                names.append(rs.getString(1)).append(',');
+            }
+        }
+        return names.toString();
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
+++ b/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @ActiveProfiles("integration")
 public abstract class IntegrationTestSupport {
 
-    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+    public static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
 
     static {
         POSTGRES.start();


### PR DESCRIPTION
## O que muda

`V2__seed_dev_data.sql` vivia em `db/migration`, então o Flyway a executava em **todo** ambiente —
criando em produção quatro contas com senha conhecida (`gestor123` e companhia).

### Decisão registrada: separar por location

Das duas estratégias da issue, escolhi a **primeira** (separar por location) em vez de mover para
`src/test/resources`. Motivo: o seed serve para quem sobe a app localmente e quer telas com dado,
não só para teste. Mandá-lo para `test/resources` resolveria produção e quebraria o
desenvolvimento — e os testes de integração, como se vê no diff, não usam o seed: eles constroem
os próprios fixtures.

| Ambiente | `spring.flyway.locations` |
|---|---|
| padrão (produção) | `classpath:db/migration` |
| profile `dev` | `classpath:db/migration,classpath:db/seed` |

### Por que a versão virou 9000 e não continuou 2

O Flyway funde os dois locations em **uma sequência única de versões**. Com o seed em `V2`, a
próxima migration real de produção também seria `V2` e os dois ambientes divergiriam no mesmo
número — erro de checksum na primeira vez que alguém subisse as duas juntas. Número alto mantém as
duas faixas separadas para sempre.

Isso cria dois efeitos colaterais, ambos resolvidos **só no profile dev**:

- `out-of-order: true` — sem isso, uma `V3` nova de produção seria recusada em dev por ter número
  menor que a 9000 já aplicada.
- `ignore-migration-patterns: "*:missing"` — banco de dev que já aplicou o seed quando ele era a
  `V2` tem no histórico uma versão que não existe mais em lugar nenhum. Sem isso o Flyway trava com
  `applied migration not resolved locally` e o único caminho seria recriar o banco.

Produção não recebe nenhuma das duas: lá o histórico é linear e completo.

Closes #7

## Como validar

```
./mvnw -B clean verify
```

`SeedMigrationIsolationTest` roda o Flyway pela API Java em um **banco novo por caso** — afirmar
sobre configuração do Flyway subindo dois contextos Spring contra o mesmo banco daria um teste
que depende da ordem de execução:

| Caso | Afirmação |
|---|---|
| locations de produção | `users`, `ideas`, `projects` e `strategies` vazias |
| locations de produção | `flyway_schema_history` **não** tem a versão `9000`, e **tem** a `1` |
| locations de dev | 4 usuários, 1 `LIDERANCA`, versão `9000` no histórico |
| os dois lados | mesma lista de tabelas — só o conteúdo difere |

> O `clean` importa: `git mv` move o fonte, não o `target/classes`. Sem ele a `V2` antiga fica
> para trás no artefato e o teste falha com `duplicate key value violates unique constraint`.

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff — as senhas do seed continuam versionadas, agora sem alcançar produção
- [x] Migration nova é idempotente e não roda em produção sem querer — **é o objeto deste PR**
- [x] Mudança de contrato de API está refletida no `README.md`
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta — n/a

## Risco

**Ambiente de dev que já aplicou a antiga V2** vai encontrar no histórico uma versão sem arquivo
correspondente. O `ignore-migration-patterns: "*:missing"` do profile dev cobre isso sem
intervenção; quem preferir histórico limpo recria o banco (`docker rm -f aguiabranca-db`).

**Produção que já rodou a V2** — não é o caso aqui, o schema ainda não foi para lugar nenhum, mas
se fosse: as contas do seed já estariam criadas e este PR não as remove. Seria preciso uma
migration de limpeza. Vale conferir antes do primeiro deploy real.

A #8 cria a `V3` e depende desta decisão estar fechada.

Base do PR é `fix/jwt-secret-env` (#6).