### PR TITLE
chore(cors): origens permitidas configuraveis por ambiente

### DIFF
--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
@@ -1,0 +1,23 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Origens autorizadas a chamar a API de um navegador.
+ *
+ * Lista vazia por default e a decisao central: entregar pronto e desligado. Enquanto o unico
+ * cliente for o app Android — que nao passa por CORS —, nenhuma origem cross-origin funciona
+ * sem alguem escrever explicitamente qual.
+ */
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(List<String> allowedOrigins) {
+
+    public CorsProperties {
+        allowedOrigins = allowedOrigins == null ? List.of() : List.copyOf(allowedOrigins);
+    }
+
+    public boolean isEnabled() {
+        return !allowedOrigins.isEmpty();
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -5,6 +5,8 @@ import br.com.fiap.aguiabranca.shared.GlobalExceptionHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,18 +19,24 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class })
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
     private final ObjectMapper objectMapper;
+    private final CorsProperties corsProperties;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtFilter, ObjectMapper objectMapper) {
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter, ObjectMapper objectMapper,
+            CorsProperties corsProperties) {
         this.jwtFilter = jwtFilter;
         this.objectMapper = objectMapper;
+        this.corsProperties = corsProperties;
     }
 
     @Bean
@@ -36,6 +44,7 @@ public class SecurityConfig {
         return http
                 // API stateless com token: nao ha sessao nem formulario para o CSRF proteger.
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/login").permitAll()
@@ -69,6 +78,32 @@ public class SecurityConfig {
         response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
         objectMapper.writeValue(response.getOutputStream(),
                 GlobalExceptionHandler.asMap(status, type, title, detail, instance));
+    }
+
+    /**
+     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos controllers:
+     * anotacao por controller e o que faz uma rota nova nascer com regra diferente das outras.
+     *
+     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao cross-origin recebe
+     * Access-Control-Allow-Origin, entao o navegador barra.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        if (corsProperties.isEnabled()) {
+            CorsConfiguration configuration = new CorsConfiguration();
+            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio Spring
+            // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
+            configuration.setAllowedOrigins(corsProperties.allowedOrigins());
+            configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Request-Id"));
+            configuration.setAllowCredentials(true);
+            configuration.setMaxAge(Duration.ofHours(1));
+            source.registerCorsConfiguration("/**", configuration);
+        }
+
+        return source;
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,12 @@ spring:
     locations: classpath:db/migration
 
 app:
+  cors:
+    # Vazio por default: nenhuma origem cross-origin passa sem configuracao explicita.
+    # O cliente atual e o app Android, que nao e afetado por CORS — isto fica pronto e
+    # desligado, esperando um front web existir.
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
   jwt:
     # Sem default: a aplicacao nao sobe sem JWT_SECRET no ambiente. Para desenvolvimento,
     # o valor vem do profile dev (application-dev.yml), nunca daqui.

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
@@ -1,0 +1,31 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+/**
+ * Configuracao default — nenhuma origem listada. Nada de cross-origin pode passar.
+ */
+class CorsDisabledIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("Sem origem configurada, o preflight nao recebe Allow-Origin")
+    void shouldNotAllowAnyOriginByDefault() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", "https://qualquer-um.example")
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Sem origem configurada, resposta normal tambem nao ganha Allow-Origin")
+    void shouldNotDecorateSimpleRequests() throws Exception {
+        mockMvc.perform(get("/ideas").header("Origin", "https://qualquer-um.example"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
@@ -1,0 +1,63 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = "app.cors.allowed-origins=https://hub.aguiabranca.dev")
+class CorsEnabledIntegrationTest extends IntegrationTestSupport {
+
+    private static final String ALLOWED = "https://hub.aguiabranca.dev";
+    private static final String DENIED = "https://site-qualquer.example";
+
+    @Test
+    @DisplayName("Preflight de origem permitida responde 200 com os headers corretos")
+    void shouldAllowConfiguredOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+    }
+
+    @Test
+    @DisplayName("Preflight de origem nao listada e recusado")
+    void shouldRejectUnknownOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", DENIED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Authorization esta entre os headers permitidos")
+    void shouldAllowAuthorizationHeader() throws Exception {
+        // Sem isto o navegador barra o preflight e nenhuma chamada autenticada sai do front.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET")
+                .header("Access-Control-Request-Headers", "Authorization"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Headers", containsString("Authorization")));
+    }
+
+    @Test
+    @DisplayName("Com credenciais habilitadas, Allow-Origin nunca sai como curinga")
+    void shouldNeverEchoWildcardWithCredentials() throws Exception {
+        // "*" com allowCredentials e recusado pelo proprio Spring em runtime; o header tem
+        // que ecoar a origem que pediu.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "POST"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED));
+    }
+}


### PR DESCRIPTION
## O que muda

Entrega a configuração de CORS **pronta e desligada**, como a issue pede. O cliente atual é o app
Android, que não passa por CORS; isto existe para o dia em que houver um front web — e para que
nesse dia ninguém resolva o problema com `allowedOrigins("*")` às pressas.

- `app.cors.allowed-origins` (via `CORS_ALLOWED_ORIGINS`), **vazio por default**
- `CorsConfigurationSource` único no `SecurityConfig`, não `@CrossOrigin` espalhado pelos controllers
- `Authorization` entre os headers permitidos
- `allowCredentials(true)` com lista explícita de origens

Closes #10

### Duas escolhas que valem explicar

**Fonte única em vez de `@CrossOrigin` por controller.** Anotação espalhada é o que faz uma rota
nova nascer com regra diferente das outras — e ninguém percebe até um endpoint específico falhar
no navegador.

**Lista explícita, nunca `*`.** A combinação `allowedOrigins("*")` + `allowCredentials(true)` é
recusada pelo próprio Spring em runtime. Com lista explícita, o header sai ecoando a origem que
pediu, que é o comportamento correto quando há credencial na jogada.

## Como validar

```
./mvnw -B clean verify
```

Dois contextos, porque o que muda é configuração e não estado:

`CorsEnabledIntegrationTest` (`app.cors.allowed-origins=https://hub.aguiabranca.dev`):

| Preflight | Esperado |
|---|---|
| origem listada | 200, `Access-Control-Allow-Origin: https://hub.aguiabranca.dev` |
| origem não listada | 403, **sem** `Access-Control-Allow-Origin` |
| `Access-Control-Request-Headers: Authorization` | 200, `Authorization` no `Allow-Headers` |
| com credenciais | `Allow-Origin` ecoa a origem, nunca `*` |

`CorsDisabledIntegrationTest` (default, lista vazia): nem preflight nem requisição simples recebem
`Access-Control-Allow-Origin`.

`Tests run: 33, Failures: 0, Errors: 0, Skipped: 0`

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer — n/a
- [x] Mudança de contrato de API está refletida no `README.md` — n/a, não muda contrato
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta — n/a, CORS não afeta cliente nativo

## Risco

Baixo por construção: o default não muda nada do comportamento atual. O risco real é futuro —
alguém precisar de CORS, não achar a property e cair no `*`. O teste
`shouldNeverEchoWildcardWithCredentials` existe para falhar o build nesse caso.

Base do PR é `fix/seed-por-profile` (#7).