### PR TITLE
feat(api): leva o stack da aplicacao para a main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copie para .env e preencha. O .env real nao vai para o git (ver .gitignore).
+
+# Segredo de assinatura do JWT (HS256). Minimo de 32 bytes — a aplicacao nao sobe abaixo disso.
+# Gere o seu com:  openssl rand -base64 48
+# Nunca reaproveite o valor do profile dev: ele e publico, esta versionado no repositorio.
+JWT_SECRET=
+
+# Banco
+DB_URL=jdbc:postgresql://localhost:5432/aguiabranca
+DB_USERNAME=aguiabranca
+DB_PASSWORD=

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,30 @@
-# Dono padrão de tudo que não casar com uma regra mais específica abaixo.
+# A ULTIMA regra que casa com o arquivo e a que vale -- por isso o curinga vem
+# primeiro e as areas depois. Inverter a ordem faz o curinga engolir todas elas.
+#
+# CODEOWNERS so surte efeito para quem tem permissao de ESCRITA no repositorio:
+# colaborador sem write e ignorado sem aviso nenhum. Valide pela aba
+# Settings > Branches (#5), nunca pelo conteudo deste arquivo.
+
+# Dono padrao de tudo que nao casar com uma regra mais especifica abaixo.
 *                       @AlexCajeFelix
 
-# Infraestrutura e pipeline
-/.github/               @AlexCajeFelix
-/Dockerfile             @AlexCajeFelix
-/compose.yaml           @AlexCajeFelix
+# Backend -- as quatro fatias, de controller a repository
+/src/main/java/         @AlexCajeFelix
+/src/test/java/         @AlexCajeFelix
 
-# Banco — migrations são caminho sem volta em produção
+# Banco -- migration e caminho sem volta em producao; revisao aqui nao e opcional
 /src/main/resources/db/ @AlexCajeFelix
+
+# Infra -- pipeline, build e wrapper
+/.github/               @AlexCajeFelix
+/pom.xml                @AlexCajeFelix
+/mvnw                   @AlexCajeFelix
+/mvnw.cmd               @AlexCajeFelix
+/.mvn/                  @AlexCajeFelix
+
+# Android nao tem regra aqui de proposito: o app vive fora deste repositorio.
+# As issues area:android sao rastreadas neste board, o codigo nao.
+#
+# /Dockerfile e /compose.yaml sairam da lista: ainda nao existem (#12), e caminho
+# inexistente o GitHub ignora em silencio -- a regra aparenta proteger o arquivo
+# e nao protege nada. Voltam no mesmo PR que criar os arquivos.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# Issue em branco desativada: sem template ninguem preenche area, contexto e criterio
+# de aceite -- e issue sem criterio verificavel nao sai do Backlog de qualquer jeito.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Board do projeto
+    url: https://github.com/users/AlexCajeFelix/projects/4
+    about: Antes de abrir, confira se o trabalho ja esta rastreado num card.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,74 @@ Backend do **Hub de Inovação e Gestão de Projetos Corporativos**: API que sub
 hoje consumidos pelo app Android via `ApiRepository` (npoint.io + fallback hardcoded) por
 persistência real.
 
-> **Status:** repositório em fundação. O código da aplicação ainda não foi commitado —
-> o backlog de implementação está nas [issues](../../issues) e no
+> **Status:** aplicação de pé. As quatro fatias (`auth`, `idea`, `project`, `strategy`) têm
+> controller, service, repository e DTOs; o schema é versionado por Flyway. O backlog de
+> endurecimento, operação e testes está nas [issues](../../issues) e no
 > [board](https://github.com/users/AlexCajeFelix/projects/4).
 
-**Comece pela issue [#1](../../issues/1) e depois a [#2](../../issues/2).** Elas destravam
-todo o resto do backlog — nada de M2 em diante deve começar antes delas.
+## Rodando local
+
+Precisa de **Docker** (o Postgres dos testes sobe por Testcontainers) e de um Postgres para a app:
+
+```bash
+docker run -d --name aguiabranca-db -p 5432:5432 \
+  -e POSTGRES_DB=aguiabranca -e POSTGRES_USER=aguiabranca -e POSTGRES_PASSWORD=aguiabranca \
+  postgres:16-alpine
+
+SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
+```
+
+### O segredo do JWT
+
+A aplicação **não sobe** sem `JWT_SECRET`, e recusa segredo com menos de 32 bytes — HS256 assina
+com bloco de 256 bits, e chave menor enfraquece a assinatura. Gere o seu:
+
+```bash
+openssl rand -base64 48
+```
+
+O profile `dev` traz um segredo pronto para não travar quem está começando. Ele é **público**:
+está versionado em `application-dev.yml`, então qualquer pessoa que leia o repositório consegue
+forjar um token de `LIDERANCA`. Por isso a aplicação recusa o boot se esse valor aparecer com
+qualquer profile diferente de `dev`.
+
+Fora de dev, a variável vem do ambiente — `.env.example` lista o que preencher.
+
+O Flyway aplica `V1__initial_schema.sql` em qualquer ambiente. O seed de desenvolvimento vive em
+`db/seed/` e **só entra com o profile `dev`** — em produção essas linhas não existem. Usuários
+criados pelo seed, um por perfil:
+
+| E-mail | Senha | Perfil |
+|---|---|---|
+| `operador@aguiabranca.dev` | `operador123` | `OPERADOR` |
+| `gestor@aguiabranca.dev` | `gestor123` | `GESTOR` |
+| `lideranca@aguiabranca.dev` | `lideranca123` | `LIDERANCA` |
+
+```bash
+curl -s localhost:8080/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"gestor@aguiabranca.dev","password":"gestor123"}'
+```
+
+## Rotas
+
+| Método | Rota | Quem pode |
+|---|---|---|
+| `POST` | `/auth/login` | público |
+| `POST` | `/ideas` | qualquer autenticado |
+| `GET` | `/ideas?status=` | autenticado — `OPERADOR` só vê as próprias |
+| `GET` | `/ideas/{id}` | autenticado — ideia alheia responde 404 para `OPERADOR` |
+| `POST` | `/ideas/{id}/approval` | `GESTOR`, `LIDERANCA` |
+| `GET` | `/projects` | qualquer autenticado |
+| `GET` | `/projects/summary` | qualquer autenticado |
+| `GET` | `/projects/{id}` | qualquer autenticado |
+| `GET` | `/projects/{id}/metrics-history` | qualquer autenticado |
+| `POST` | `/projects/from-idea/{ideaId}` | `GESTOR`, `LIDERANCA` |
+| `PATCH` | `/projects/{id}/metrics` | `GESTOR`, `LIDERANCA` |
+| `GET` | `/strategies`, `/strategies/{id}` | qualquer autenticado |
+| `POST` `PUT` `DELETE` | `/strategies` | `GESTOR`, `LIDERANCA` |
+
+Erro sai em RFC 7807. O campo estável para o cliente decidir comportamento é o **`type`**, nunca
+o `title` — que é texto livre e muda.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ curl -s localhost:8080/auth/login -H 'Content-Type: application/json' \
 Erro sai em RFC 7807. O campo estável para o cliente decidir comportamento é o **`type`**, nunca
 o `title` — que é texto livre e muda.
 
+### Correlation ID
+
+Toda resposta volta com o header **`X-Request-Id`**, e toda linha de log da requisição sai com o
+mesmo valor entre colchetes. Se o cliente mandar o header, ele é reaproveitado; se não mandar, a
+API gera um UUID.
+
+```
+2026-08-27T10:12:03.914-03:00  WARN [app-android-7f3a] 1 --- [nio-8080-exec-2] G.ExceptionHandler : 422 em /projects/12/metrics ...
+```
+
+Em resposta de erro o mesmo ID aparece no `instance` do ProblemDetail, como
+`urn:request-id:<id>` — então um print de tela do erro basta para achar as linhas de log daquela
+requisição exata, sem caçar por horário.
+
+Valor recebido do cliente é limpo antes de entrar no log: acima de 64 caracteres, ou sobrando
+vazio depois da limpeza, a API descarta e gera o próprio.
+
 ---
 
 ## Índice

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
 	<properties>
 		<java.version>21</java.version>
+		<jjwt.version>0.12.6</jjwt.version>
 		<!-- O Testcontainers gerenciado pelo Boot 3.3.5 (1.19.8) fixa a API Docker 1.32
 		     internamente, e o Docker Engine >= 29 recusa: "client version 1.32 is too old.
 		     Minimum supported API version is 1.40". Com 1.19.8 o teste nao falha — ele e
@@ -39,6 +40,32 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>${jjwt.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
@@ -55,6 +82,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthController.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthController.java
@@ -1,0 +1,25 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    // TODO(#9): sem rate limit — aceita tentativas ilimitadas de senha.
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthService.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthService.java
@@ -1,0 +1,34 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.User;
+import br.com.fiap.aguiabranca.domain.user.UserRepository;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    private final UserRepository users;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    public AuthService(UserRepository users, PasswordEncoder passwordEncoder, JwtService jwtService) {
+        this.users = users;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+    }
+
+    @Transactional(readOnly = true)
+    public TokenResponse login(LoginRequest request) {
+        User user = users.findByEmail(request.email())
+                .orElseThrow(() -> new BadCredentialsException("credenciais invalidas"));
+
+        if (!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
+            throw new BadCredentialsException("credenciais invalidas");
+        }
+
+        return new TokenResponse(jwtService.generate(user), jwtService.expiresInSeconds(), user.getRole());
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthenticatedUser.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthenticatedUser.java
@@ -1,0 +1,21 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.domain.user.User;
+
+/**
+ * Principal da requisicao autenticada.
+ *
+ * Carrega id e role vindos do token, sem tocar o banco a cada request. O id e o que permite
+ * ao service decidir "esta ideia e sua?" sem recarregar o usuario.
+ */
+public record AuthenticatedUser(Long id, String email, Role role) {
+
+    public static AuthenticatedUser from(User user) {
+        return new AuthenticatedUser(user.getId(), user.getEmail(), user.getRole());
+    }
+
+    public boolean isOperador() {
+        return role == Role.OPERADOR;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/CorsProperties.java
@@ -1,0 +1,23 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Origens autorizadas a chamar a API de um navegador.
+ *
+ * Lista vazia por default e a decisao central: entregar pronto e desligado. Enquanto o unico
+ * cliente for o app Android — que nao passa por CORS —, nenhuma origem cross-origin funciona
+ * sem alguem escrever explicitamente qual.
+ */
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(List<String> allowedOrigins) {
+
+    public CorsProperties {
+        allowedOrigins = allowedOrigins == null ? List.of() : List.copyOf(allowedOrigins);
+    }
+
+    public boolean isEnabled() {
+        return !allowedOrigins.isEmpty();
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String PREFIX = "Bearer ";
+
+    private final JwtService jwtService;
+
+    public JwtAuthenticationFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain chain) throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith(PREFIX)) {
+            AuthenticatedUser user = jwtService.parse(header.substring(PREFIX.length()));
+            if (user != null) {
+                var authentication = new UsernamePasswordAuthenticationToken(
+                        user, null, List.of(new SimpleGrantedAuthority(user.role().authority())));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            // Token invalido nao lanca aqui: segue anonimo e o entry point responde 401.
+            // Lancar do filtro pularia o tratamento padronizado em ProblemDetail.
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtProperties.java
@@ -1,0 +1,36 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * TODO(#8): expiration de 8h sem refresh — o app expulsa o usuario no meio do uso.
+ */
+@ConfigurationProperties(prefix = "app.jwt")
+public record JwtProperties(String secret, Duration expiration) {
+
+    /** HS256 assina com bloco de 256 bits: chave menor enfraquece a assinatura. */
+    static final int MIN_SECRET_BYTES = 32;
+
+    /**
+     * Valida na propria vinculacao da propriedade, nao num listener depois do boot.
+     *
+     * A jjwt 0.12 tambem recusa chave curta, mas so na primeira assinatura — ou seja, no
+     * primeiro login de um usuario real, em runtime. Aqui a aplicacao simplesmente nao sobe.
+     */
+    public JwtProperties {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException(
+                    "JWT_SECRET nao definida. Gere uma com: openssl rand -base64 48");
+        }
+
+        int bytes = secret.getBytes(StandardCharsets.UTF_8).length;
+        if (bytes < MIN_SECRET_BYTES) {
+            // Informa o tamanho, nunca o valor: mensagem de erro vai para log, e log vaza.
+            throw new IllegalStateException(
+                    "JWT_SECRET tem " + bytes + " bytes; o minimo para HS256 e " + MIN_SECRET_BYTES
+                            + ". Gere uma com: openssl rand -base64 48");
+        }
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretGuard.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretGuard.java
@@ -1,0 +1,29 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.util.Arrays;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Impede que o segredo de desenvolvimento suba em ambiente que nao seja dev.
+ *
+ * O valor de dev esta versionado em application-dev.yml — qualquer um que leia o repositorio
+ * consegue forjar um token de LIDERANCA. O tamanho dele passa na validacao de bytes do
+ * JwtProperties, entao so essa checagem por valor o pega.
+ */
+@Component
+class JwtSecretGuard {
+
+    static final String DEV_SECRET = "dev-secret-nao-use-em-producao-troque-me-agora";
+
+    JwtSecretGuard(JwtProperties properties, Environment environment) {
+        boolean devProfile = Arrays.asList(environment.getActiveProfiles()).contains("dev");
+
+        if (!devProfile && DEV_SECRET.equals(properties.secret())) {
+            throw new IllegalStateException(
+                    "JWT_SECRET esta com o valor de desenvolvimento, que e publico no repositorio, "
+                            + "e o profile ativo nao e dev. Defina JWT_SECRET no ambiente. "
+                            + "Gere uma com: openssl rand -base64 48");
+        }
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtService.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtService.java
@@ -1,0 +1,66 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.domain.user.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Service;
+import io.jsonwebtoken.security.Keys;
+
+/** Assina e valida o access token HS256. A role viaja como claim, conforme o README. */
+@Service
+public class JwtService {
+
+    private static final String CLAIM_ROLE = "role";
+    private static final String CLAIM_EMAIL = "email";
+
+    private final SecretKey key;
+    private final JwtProperties properties;
+
+    public JwtService(JwtProperties properties) {
+        this.properties = properties;
+        this.key = Keys.hmacShaKeyFor(properties.secret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generate(User user) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .claim(CLAIM_EMAIL, user.getEmail())
+                .claim(CLAIM_ROLE, user.getRole().name())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(properties.expiration())))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Devolve o principal do token, ou null se o token for invalido por qualquer motivo
+     * (assinatura, expiracao, formato). O filtro trata todos igual: sem autenticacao.
+     */
+    public AuthenticatedUser parse(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            return new AuthenticatedUser(
+                    Long.valueOf(claims.getSubject()),
+                    claims.get(CLAIM_EMAIL, String.class),
+                    Role.valueOf(claims.get(CLAIM_ROLE, String.class)));
+        } catch (JwtException | IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    public long expiresInSeconds() {
+        return properties.expiration().toSeconds();
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/LoginRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/LoginRequest.java
@@ -1,0 +1,9 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "E-mail e obrigatorio") @Email(message = "E-mail invalido") String email,
+        @NotBlank(message = "Senha e obrigatoria") String password) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -2,6 +2,7 @@ package br.com.fiap.aguiabranca.domain.auth;
 
 import br.com.fiap.aguiabranca.shared.ErrorTypes;
 import br.com.fiap.aguiabranca.shared.GlobalExceptionHandler;
+import br.com.fiap.aguiabranca.shared.RequestId;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -62,14 +63,16 @@ public class SecurityConfig {
     private void unauthenticated(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.core.AuthenticationException ex) throws java.io.IOException {
         write(response, HttpStatus.UNAUTHORIZED, ErrorTypes.UNAUTHENTICATED, "Nao autenticado",
-                "Envie um token valido no header Authorization.", request.getRequestURI());
+                "Envie um token valido no header Authorization.",
+                GlobalExceptionHandler.instanceOf(request).toString());
     }
 
     /** Autenticado, mas sem o perfil exigido: 403. O app apenas informa, nao desloga. */
     private void forbidden(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.access.AccessDeniedException ex) throws java.io.IOException {
         write(response, HttpStatus.FORBIDDEN, ErrorTypes.FORBIDDEN, "Sem permissao",
-                "Seu perfil nao tem permissao para esta operacao.", request.getRequestURI());
+                "Seu perfil nao tem permissao para esta operacao.",
+                GlobalExceptionHandler.instanceOf(request).toString());
     }
 
     private void write(HttpServletResponse response, HttpStatus status, String type, String title,
@@ -97,7 +100,10 @@ public class SecurityConfig {
             // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
             configuration.setAllowedOrigins(corsProperties.allowedOrigins());
             configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Request-Id"));
+            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", RequestId.HEADER));
+            // Exposto, e nao so permitido: header de resposta fora da lista branca do CORS o
+            // navegador esconde do JavaScript. O ID chegaria e o front nao conseguiria le-lo.
+            configuration.setExposedHeaders(List.of(RequestId.HEADER));
             configuration.setAllowCredentials(true);
             configuration.setMaxAge(Duration.ofHours(1));
             source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -1,0 +1,113 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.shared.ErrorTypes;
+import br.com.fiap.aguiabranca.shared.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableMethodSecurity
+@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class })
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtFilter;
+    private final ObjectMapper objectMapper;
+    private final CorsProperties corsProperties;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter, ObjectMapper objectMapper,
+            CorsProperties corsProperties) {
+        this.jwtFilter = jwtFilter;
+        this.objectMapper = objectMapper;
+        this.corsProperties = corsProperties;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                // API stateless com token: nao ha sessao nem formulario para o CSRF proteger.
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/login").permitAll()
+                        // Publica para o healthcheck do compose (#12) conseguir bater sem token.
+                        .requestMatchers("/actuator/health").permitAll()
+                        .anyRequest().authenticated())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(this::unauthenticated)
+                        .accessDeniedHandler(this::forbidden))
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    /** Sem token, ou token invalido: 401. O app da #22 trata isso como sessao expirada. */
+    private void unauthenticated(HttpServletRequest request, HttpServletResponse response,
+            org.springframework.security.core.AuthenticationException ex) throws java.io.IOException {
+        write(response, HttpStatus.UNAUTHORIZED, ErrorTypes.UNAUTHENTICATED, "Nao autenticado",
+                "Envie um token valido no header Authorization.", request.getRequestURI());
+    }
+
+    /** Autenticado, mas sem o perfil exigido: 403. O app apenas informa, nao desloga. */
+    private void forbidden(HttpServletRequest request, HttpServletResponse response,
+            org.springframework.security.access.AccessDeniedException ex) throws java.io.IOException {
+        write(response, HttpStatus.FORBIDDEN, ErrorTypes.FORBIDDEN, "Sem permissao",
+                "Seu perfil nao tem permissao para esta operacao.", request.getRequestURI());
+    }
+
+    private void write(HttpServletResponse response, HttpStatus status, String type, String title,
+            String detail, String instance) throws java.io.IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(),
+                GlobalExceptionHandler.asMap(status, type, title, detail, instance));
+    }
+
+    /**
+     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos controllers:
+     * anotacao por controller e o que faz uma rota nova nascer com regra diferente das outras.
+     *
+     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao cross-origin recebe
+     * Access-Control-Allow-Origin, entao o navegador barra.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        if (corsProperties.isEnabled()) {
+            CorsConfiguration configuration = new CorsConfiguration();
+            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio Spring
+            // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
+            configuration.setAllowedOrigins(corsProperties.allowedOrigins());
+            configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Request-Id"));
+            configuration.setAllowCredentials(true);
+            configuration.setMaxAge(Duration.ofHours(1));
+            source.registerCorsConfiguration("/**", configuration);
+        }
+
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(10);
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/TokenResponse.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/TokenResponse.java
@@ -1,0 +1,6 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+
+public record TokenResponse(String accessToken, long expiresIn, Role role) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/Idea.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/Idea.java
@@ -1,14 +1,22 @@
 package br.com.fiap.aguiabranca.domain.idea;
 
+import br.com.fiap.aguiabranca.domain.user.User;
+import br.com.fiap.aguiabranca.shared.DomainRuleException;
+import br.com.fiap.aguiabranca.shared.ErrorTypes;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.Objects;
 
 @Entity
@@ -36,6 +44,20 @@ public class Idea {
     @Enumerated(EnumType.STRING)
     private Status status = Status.DRAFT;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private User owner;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewed_by_id")
+    private User reviewedBy;
+
+    @Column(name = "reviewed_at")
+    private Instant reviewedAt;
+
     public Idea() {
     }
 
@@ -43,13 +65,43 @@ public class Idea {
         this.title = title;
         this.description = description;
         this.status = Status.DRAFT;
+        this.createdAt = Instant.now();
+    }
+
+    public Idea(String title, String description, User owner) {
+        this(title, description);
+        this.owner = owner;
     }
 
     public void review(Status newStatus) {
+        review(newStatus, null);
+    }
+
+    public void review(Status newStatus, User reviewer) {
         if (newStatus == null || newStatus == Status.DRAFT) {
             throw new IllegalArgumentException("Status de revisão inválido");
         }
+        // Revisar de novo o que ja foi decidido apagaria a decisao anterior sem deixar rastro.
+        if (isReviewed()) {
+            throw new DomainRuleException(ErrorTypes.IDEA_ALREADY_REVIEWED,
+                    "Ideia já revisada com status " + this.status + ".");
+        }
         this.status = newStatus;
+        this.reviewedBy = reviewer;
+        this.reviewedAt = Instant.now();
+    }
+
+    public boolean isReviewed() {
+        return status == Status.APPROVED || status == Status.REJECTED;
+    }
+
+    public boolean isApproved() {
+        return status == Status.APPROVED;
+    }
+
+    /** O OPERADOR so enxerga o que e dele; os demais perfis enxergam tudo. */
+    public boolean isOwnedBy(Long userId) {
+        return owner != null && Objects.equals(owner.getId(), userId);
     }
 
     public Long getId() {
@@ -66,6 +118,22 @@ public class Idea {
 
     public Status getStatus() {
         return status;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public User getReviewedBy() {
+        return reviewedBy;
+    }
+
+    public Instant getReviewedAt() {
+        return reviewedAt;
     }
 
     @Override

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaController.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaController.java
@@ -1,0 +1,58 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import br.com.fiap.aguiabranca.domain.auth.AuthenticatedUser;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ideas")
+public class IdeaController {
+
+    private final IdeaService ideaService;
+
+    public IdeaController(IdeaService ideaService) {
+        this.ideaService = ideaService;
+    }
+
+    /** Qualquer perfil autenticado submete ideia — inclusive o OPERADOR. */
+    @PostMapping
+    public ResponseEntity<IdeaResponse> submit(@Valid @RequestBody IdeaRequest request,
+            @AuthenticationPrincipal AuthenticatedUser actor) {
+
+        Idea idea = ideaService.submit(request, actor);
+        return ResponseEntity
+                .created(URI.create("/ideas/" + idea.getId()))
+                .body(IdeaResponse.from(idea));
+    }
+
+    @GetMapping
+    public List<IdeaResponse> list(@RequestParam(required = false) Idea.Status status,
+            @AuthenticationPrincipal AuthenticatedUser actor) {
+
+        return ideaService.list(status, actor).stream().map(IdeaResponse::from).toList();
+    }
+
+    @GetMapping("/{id}")
+    public IdeaResponse findById(@PathVariable Long id, @AuthenticationPrincipal AuthenticatedUser actor) {
+        return IdeaResponse.from(ideaService.findVisible(id, actor));
+    }
+
+    @PostMapping("/{id}/approval")
+    @PreAuthorize("hasAnyRole('GESTOR', 'LIDERANCA')")
+    public IdeaResponse review(@PathVariable Long id, @Valid @RequestBody IdeaReviewRequest request,
+            @AuthenticationPrincipal AuthenticatedUser actor) {
+
+        return IdeaResponse.from(ideaService.review(id, request, actor));
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaRepository.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaRepository.java
@@ -1,0 +1,20 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IdeaRepository extends JpaRepository<Idea, Long> {
+
+    List<Idea> findAllByStatusOrderByIdDesc(Idea.Status status);
+
+    List<Idea> findAllByOwnerIdOrderByIdDesc(Long ownerId);
+
+    List<Idea> findAllByOwnerIdAndStatusOrderByIdDesc(Long ownerId, Idea.Status status);
+
+    List<Idea> findAllByOrderByIdDesc();
+
+    Optional<Idea> findByIdAndOwnerId(Long id, Long ownerId);
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaRequest.java
@@ -1,0 +1,9 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record IdeaRequest(
+        @NotBlank(message = "Título é obrigatório") @Size(max = 150, message = "Título tem no máximo 150 caracteres") String title,
+        @NotBlank(message = "Descrição é obrigatória") String description) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaResponse.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaResponse.java
@@ -1,0 +1,24 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import java.time.Instant;
+
+public record IdeaResponse(
+        Long id,
+        String title,
+        String description,
+        Idea.Status status,
+        Long ownerId,
+        Instant createdAt,
+        Instant reviewedAt) {
+
+    public static IdeaResponse from(Idea idea) {
+        return new IdeaResponse(
+                idea.getId(),
+                idea.getTitle(),
+                idea.getDescription(),
+                idea.getStatus(),
+                idea.getOwner() == null ? null : idea.getOwner().getId(),
+                idea.getCreatedAt(),
+                idea.getReviewedAt());
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaReviewRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaReviewRequest.java
@@ -1,0 +1,8 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import jakarta.validation.constraints.NotNull;
+
+/** DRAFT aqui e recusado pela entidade: revisar e sair do rascunho, nao voltar para ele. */
+public record IdeaReviewRequest(
+        @NotNull(message = "Status é obrigatório") Idea.Status status) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaService.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/idea/IdeaService.java
@@ -1,0 +1,65 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import br.com.fiap.aguiabranca.domain.auth.AuthenticatedUser;
+import br.com.fiap.aguiabranca.domain.user.User;
+import br.com.fiap.aguiabranca.domain.user.UserRepository;
+import br.com.fiap.aguiabranca.shared.ErrorTypes;
+import br.com.fiap.aguiabranca.shared.ResourceNotFoundException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class IdeaService {
+
+    private final IdeaRepository ideas;
+    private final UserRepository users;
+
+    public IdeaService(IdeaRepository ideas, UserRepository users) {
+        this.ideas = ideas;
+        this.users = users;
+    }
+
+    @Transactional
+    public Idea submit(IdeaRequest request, AuthenticatedUser actor) {
+        User owner = users.getReferenceById(actor.id());
+        return ideas.save(new Idea(request.title(), request.description(), owner));
+    }
+
+    /**
+     * O recorte por dono acontece na consulta, nao filtrando a lista depois: filtrar em
+     * memoria ainda traz a ideia alheia do banco e vaza no dia em que alguem esquecer o filtro.
+     */
+    @Transactional(readOnly = true)
+    public List<Idea> list(Idea.Status status, AuthenticatedUser actor) {
+        if (actor.isOperador()) {
+            return status == null
+                    ? ideas.findAllByOwnerIdOrderByIdDesc(actor.id())
+                    : ideas.findAllByOwnerIdAndStatusOrderByIdDesc(actor.id(), status);
+        }
+        return status == null ? ideas.findAllByOrderByIdDesc() : ideas.findAllByStatusOrderByIdDesc(status);
+    }
+
+    /**
+     * Para o OPERADOR, ideia de outro responde 404 e nao 403: 403 confirmaria que o id existe,
+     * o que ja e vazamento — da para mapear o backlog alheio so pela diferenca de status.
+     */
+    @Transactional(readOnly = true)
+    public Idea findVisible(Long id, AuthenticatedUser actor) {
+        if (actor.isOperador()) {
+            return ideas.findByIdAndOwnerId(id, actor.id()).orElseThrow(() -> notFound(id));
+        }
+        return ideas.findById(id).orElseThrow(() -> notFound(id));
+    }
+
+    @Transactional
+    public Idea review(Long id, IdeaReviewRequest request, AuthenticatedUser actor) {
+        Idea idea = ideas.findById(id).orElseThrow(() -> notFound(id));
+        idea.review(request.status(), users.getReferenceById(actor.id()));
+        return idea;
+    }
+
+    private ResourceNotFoundException notFound(Long id) {
+        return new ResourceNotFoundException(ErrorTypes.IDEA_NOT_FOUND, "Ideia " + id + " não encontrada.");
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/DashboardResponse.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/DashboardResponse.java
@@ -1,0 +1,7 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.util.List;
+
+/** O que a tela inicial do app pede numa chamada so. */
+public record DashboardResponse(ProjectSummaryDto summary, List<ProjectStatusCount> byStatus) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/MetricsHistoryResponse.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/MetricsHistoryResponse.java
@@ -1,0 +1,21 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record MetricsHistoryResponse(
+        Long id,
+        ProjectMetricsHistory.Metric metric,
+        BigDecimal oldValue,
+        BigDecimal newValue,
+        Instant changedAt) {
+
+    public static MetricsHistoryResponse from(ProjectMetricsHistory entry) {
+        return new MetricsHistoryResponse(
+                entry.getId(),
+                entry.getMetric(),
+                entry.getOldValue(),
+                entry.getNewValue(),
+                entry.getChangedAt());
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/MetricsPatchRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/MetricsPatchRequest.java
@@ -1,0 +1,14 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.math.BigDecimal;
+
+/**
+ * PATCH parcial: os dois campos sao opcionais, mas mandar os dois nulos e erro — sem isso,
+ * um PATCH vazio responderia 200 sem ter feito nada e sem gravar historico.
+ */
+public record MetricsPatchRequest(Integer progress, BigDecimal spent) {
+
+    public boolean isEmpty() {
+        return progress == null && spent == null;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/Project.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/Project.java
@@ -1,15 +1,25 @@
 package br.com.fiap.aguiabranca.domain.project;
 
+import br.com.fiap.aguiabranca.domain.idea.Idea;
+import br.com.fiap.aguiabranca.shared.DomainRuleException;
+import br.com.fiap.aguiabranca.shared.ErrorTypes;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Objects;
 
 @Entity
@@ -30,6 +40,21 @@ public class Project {
     @NotNull
     private BigDecimal budget;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ProjectStatus status = ProjectStatus.PLANNING;
+
+    @NotNull
+    private BigDecimal spent = BigDecimal.ZERO;
+
+    // OneToOne com a coluna UNIQUE no banco: a mesma ideia nao vira dois projetos.
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "idea_id", unique = true)
+    private Idea idea;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
     public Project() {
     }
 
@@ -37,13 +62,37 @@ public class Project {
         this.name = name;
         updateProgress(progress);
         this.budget = budget;
+        this.status = ProjectStatus.PLANNING;
+        this.spent = BigDecimal.ZERO;
+        this.createdAt = Instant.now();
+    }
+
+    /** Promocao de ideia aprovada. A checagem de "aprovada" e do service, que ve o repositorio. */
+    public static Project fromIdea(Idea idea, BigDecimal budget) {
+        Project project = new Project(idea.getTitle(), 0, budget);
+        project.idea = idea;
+        return project;
     }
 
     public void updateProgress(int newProgress) {
         if (newProgress < 0 || newProgress > 100) {
-            throw new IllegalArgumentException("Progresso deve ser entre 0 e 100");
+            throw new DomainRuleException(ErrorTypes.PROJECT_INVALID_PROGRESS,
+                    "Progresso deve ser entre 0 e 100.");
         }
         this.progress = newProgress;
+        if (newProgress == 100) {
+            this.status = ProjectStatus.COMPLETED;
+        } else if (newProgress > 0 && this.status == ProjectStatus.PLANNING) {
+            this.status = ProjectStatus.IN_PROGRESS;
+        }
+    }
+
+    public void updateSpent(BigDecimal newSpent) {
+        if (newSpent == null || newSpent.signum() < 0) {
+            throw new DomainRuleException(ErrorTypes.PROJECT_INVALID_PROGRESS,
+                    "Valor gasto não pode ser negativo.");
+        }
+        this.spent = newSpent;
     }
 
     public Long getId() {
@@ -60,6 +109,22 @@ public class Project {
 
     public BigDecimal getBudget() {
         return budget;
+    }
+
+    public ProjectStatus getStatus() {
+        return status;
+    }
+
+    public BigDecimal getSpent() {
+        return spent;
+    }
+
+    public Idea getIdea() {
+        return idea;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
     }
 
     @Override

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectController.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectController.java
@@ -1,0 +1,67 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import br.com.fiap.aguiabranca.domain.auth.AuthenticatedUser;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @GetMapping
+    public List<ProjectResponse> list() {
+        return projectService.list().stream().map(ProjectResponse::from).toList();
+    }
+
+    /** Literal antes de "/{id}": o Spring casa o caminho mais especifico primeiro. */
+    @GetMapping("/summary")
+    public DashboardResponse summary() {
+        return projectService.dashboard();
+    }
+
+    @GetMapping("/{id}")
+    public ProjectResponse findById(@PathVariable Long id) {
+        return ProjectResponse.from(projectService.findById(id));
+    }
+
+    @GetMapping("/{id}/metrics-history")
+    public List<MetricsHistoryResponse> history(@PathVariable Long id) {
+        return projectService.historyOf(id).stream().map(MetricsHistoryResponse::from).toList();
+    }
+
+    @PostMapping("/from-idea/{ideaId}")
+    @PreAuthorize("hasAnyRole('GESTOR', 'LIDERANCA')")
+    public ResponseEntity<ProjectResponse> promote(@PathVariable Long ideaId,
+            @Valid @RequestBody PromoteIdeaRequest request) {
+
+        Project project = projectService.promote(ideaId, request);
+        return ResponseEntity
+                .created(URI.create("/projects/" + project.getId()))
+                .body(ProjectResponse.from(project));
+    }
+
+    @PatchMapping("/{id}/metrics")
+    @PreAuthorize("hasAnyRole('GESTOR', 'LIDERANCA')")
+    public ProjectResponse updateMetrics(@PathVariable Long id, @Valid @RequestBody MetricsPatchRequest request,
+            @AuthenticationPrincipal AuthenticatedUser actor) {
+
+        return ProjectResponse.from(projectService.updateMetrics(id, request, actor));
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectMetricsHistory.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectMetricsHistory.java
@@ -1,0 +1,98 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import br.com.fiap.aguiabranca.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Snapshot de auditoria financeira: quem mudou qual metrica, de quanto para quanto e quando.
+ *
+ * Gravado na mesma transacao da alteracao. Fora dela, um erro posterior deixaria historico
+ * de uma mudanca que nunca aconteceu.
+ */
+@Entity
+@Table(name = "project_metrics_history")
+public class ProjectMetricsHistory {
+
+    public enum Metric {
+        PROGRESS,
+        SPENT
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Metric metric;
+
+    @Column(name = "old_value")
+    private BigDecimal oldValue;
+
+    @Column(name = "new_value", nullable = false)
+    private BigDecimal newValue;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "changed_by_id", nullable = false)
+    private User changedBy;
+
+    @Column(name = "changed_at", nullable = false)
+    private Instant changedAt = Instant.now();
+
+    protected ProjectMetricsHistory() {
+    }
+
+    public ProjectMetricsHistory(Project project, Metric metric, BigDecimal oldValue, BigDecimal newValue,
+            User changedBy) {
+        this.project = project;
+        this.metric = metric;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+        this.changedBy = changedBy;
+        this.changedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public Metric getMetric() {
+        return metric;
+    }
+
+    public BigDecimal getOldValue() {
+        return oldValue;
+    }
+
+    public BigDecimal getNewValue() {
+        return newValue;
+    }
+
+    public User getChangedBy() {
+        return changedBy;
+    }
+
+    public Instant getChangedAt() {
+        return changedAt;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectMetricsHistoryRepository.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectMetricsHistoryRepository.java
@@ -1,0 +1,13 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectMetricsHistoryRepository extends JpaRepository<ProjectMetricsHistory, Long> {
+
+    List<ProjectMetricsHistory> findAllByProjectIdOrderByChangedAtAscIdAsc(Long projectId);
+
+    long countByProjectId(Long projectId);
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectRepository.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectRepository.java
@@ -1,5 +1,6 @@
 package br.com.fiap.aguiabranca.domain.project;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,13 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             "COUNT(p), AVG(p.progress), SUM(p.budget)) FROM Project p")
     ProjectSummaryDto summarize();
 
+    // COUNT devolve Long e o construtor do record exige Long: deixar int aqui explode em
+    // runtime com ConstructorResultMappingException, nao em compilacao.
+    @Query("SELECT new br.com.fiap.aguiabranca.domain.project.ProjectStatusCount(" +
+            "p.status, COUNT(p)) FROM Project p GROUP BY p.status ORDER BY p.status")
+    List<ProjectStatusCount> countByStatusGrouped();
+
+    boolean existsByIdeaId(Long ideaId);
+
+    List<Project> findAllByOrderByIdDesc();
 }

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectResponse.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectResponse.java
@@ -1,0 +1,27 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record ProjectResponse(
+        Long id,
+        String name,
+        ProjectStatus status,
+        int progress,
+        BigDecimal budget,
+        BigDecimal spent,
+        Long ideaId,
+        Instant createdAt) {
+
+    public static ProjectResponse from(Project project) {
+        return new ProjectResponse(
+                project.getId(),
+                project.getName(),
+                project.getStatus(),
+                project.getProgress(),
+                project.getBudget(),
+                project.getSpent(),
+                project.getIdea() == null ? null : project.getIdea().getId(),
+                project.getCreatedAt());
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectService.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectService.java
@@ -1,0 +1,113 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import br.com.fiap.aguiabranca.domain.auth.AuthenticatedUser;
+import br.com.fiap.aguiabranca.domain.idea.Idea;
+import br.com.fiap.aguiabranca.domain.idea.IdeaRepository;
+import br.com.fiap.aguiabranca.domain.user.User;
+import br.com.fiap.aguiabranca.domain.user.UserRepository;
+import br.com.fiap.aguiabranca.shared.DomainRuleException;
+import br.com.fiap.aguiabranca.shared.ErrorTypes;
+import br.com.fiap.aguiabranca.shared.ResourceNotFoundException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projects;
+    private final ProjectMetricsHistoryRepository history;
+    private final IdeaRepository ideas;
+    private final UserRepository users;
+
+    public ProjectService(ProjectRepository projects, ProjectMetricsHistoryRepository history,
+            IdeaRepository ideas, UserRepository users) {
+        this.projects = projects;
+        this.history = history;
+        this.ideas = ideas;
+        this.users = users;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Project> list() {
+        return projects.findAllByOrderByIdDesc();
+    }
+
+    @Transactional(readOnly = true)
+    public Project findById(Long id) {
+        return projects.findById(id).orElseThrow(() -> notFound(id));
+    }
+
+    @Transactional(readOnly = true)
+    public DashboardResponse dashboard() {
+        return new DashboardResponse(projects.summarize(), projects.countByStatusGrouped());
+    }
+
+    @Transactional
+    public Project promote(Long ideaId, PromoteIdeaRequest request) {
+        Idea idea = ideas.findById(ideaId)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorTypes.IDEA_NOT_FOUND,
+                        "Ideia " + ideaId + " não encontrada."));
+
+        if (!idea.isApproved()) {
+            throw new DomainRuleException(ErrorTypes.IDEA_NOT_APPROVED,
+                    "Só ideia aprovada vira projeto. Status atual: " + idea.getStatus() + ".");
+        }
+        if (projects.existsByIdeaId(ideaId)) {
+            throw new DomainRuleException(ErrorTypes.IDEA_ALREADY_PROMOTED,
+                    "Ideia " + ideaId + " já foi promovida a projeto.");
+        }
+
+        return projects.save(Project.fromIdea(idea, request.budget()));
+    }
+
+    /**
+     * Atualiza metrica e grava o snapshot na MESMA transacao.
+     *
+     * A ordem importa: a entidade valida antes de qualquer snapshot ir para o repositorio, e
+     * como tudo esta numa transacao so, uma validacao que estoure no meio desfaz o que veio
+     * antes. E isso que impede historico orfao de uma mudanca que nao aconteceu.
+     */
+    @Transactional
+    public Project updateMetrics(Long id, MetricsPatchRequest request, AuthenticatedUser actor) {
+        if (request.isEmpty()) {
+            throw new DomainRuleException(ErrorTypes.PROJECT_NO_METRIC,
+                    "Informe ao menos uma métrica: progress ou spent.");
+        }
+
+        Project project = projects.findById(id).orElseThrow(() -> notFound(id));
+        User changedBy = users.getReferenceById(actor.id());
+        List<ProjectMetricsHistory> snapshots = new ArrayList<>();
+
+        if (request.progress() != null) {
+            BigDecimal previous = BigDecimal.valueOf(project.getProgress());
+            project.updateProgress(request.progress());
+            snapshots.add(new ProjectMetricsHistory(project, ProjectMetricsHistory.Metric.PROGRESS,
+                    previous, BigDecimal.valueOf(project.getProgress()), changedBy));
+        }
+
+        if (request.spent() != null) {
+            BigDecimal previous = project.getSpent();
+            project.updateSpent(request.spent());
+            snapshots.add(new ProjectMetricsHistory(project, ProjectMetricsHistory.Metric.SPENT,
+                    previous, project.getSpent(), changedBy));
+        }
+
+        history.saveAll(snapshots);
+        return project;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectMetricsHistory> historyOf(Long id) {
+        if (!projects.existsById(id)) {
+            throw notFound(id);
+        }
+        return history.findAllByProjectIdOrderByChangedAtAscIdAsc(id);
+    }
+
+    private ResourceNotFoundException notFound(Long id) {
+        return new ResourceNotFoundException(ErrorTypes.PROJECT_NOT_FOUND, "Projeto " + id + " não encontrado.");
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectStatus.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectStatus.java
@@ -1,0 +1,14 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+/**
+ * Ciclo de vida do projeto.
+ *
+ * Os nomes sao contrato com o app (#24): o cliente desserializa direto neste enum, entao
+ * renomear um valor quebra a tela de filtro sem aviso.
+ */
+public enum ProjectStatus {
+    PLANNING,
+    IN_PROGRESS,
+    COMPLETED,
+    CANCELLED
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectStatusCount.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectStatusCount.java
@@ -1,0 +1,5 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+/** Uma fatia do grafico de status do dashboard. */
+public record ProjectStatusCount(ProjectStatus status, Long total) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/PromoteIdeaRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/PromoteIdeaRequest.java
@@ -1,0 +1,9 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record PromoteIdeaRequest(
+        @NotNull(message = "Orçamento é obrigatório") @DecimalMin(value = "0.0", inclusive = false, message = "Orçamento deve ser maior que zero") BigDecimal budget) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/strategy/Horizon.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/strategy/Horizon.java
@@ -1,0 +1,8 @@
+package br.com.fiap.aguiabranca.domain.strategy;
+
+/** Horizonte de tempo da estrategia. */
+public enum Horizon {
+    SHORT,
+    MEDIUM,
+    LONG
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/strategy/Strategy.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/strategy/Strategy.java
@@ -1,0 +1,111 @@
+package br.com.fiap.aguiabranca.domain.strategy;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.Objects;
+import org.hibernate.annotations.SQLRestriction;
+
+/**
+ * Estrategia corporativa, com soft delete.
+ *
+ * O @SQLRestriction aplica "deleted_at is null" em toda query gerada pelo Hibernate — a linha
+ * excluida some das leituras mas continua na tabela. Para provar que ela continua la, o teste
+ * precisa consultar por SQL nativo: pelo repositorio ela e invisivel por construcao.
+ */
+@Entity
+@Table(name = "strategies")
+@SQLRestriction("deleted_at is null")
+public class Strategy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "Título é obrigatório")
+    private String title;
+
+    @NotBlank(message = "Descrição é obrigatória")
+    private String description;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Horizon horizon;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    protected Strategy() {
+    }
+
+    public Strategy(String title, String description, Horizon horizon) {
+        this.title = title;
+        this.description = description;
+        this.horizon = horizon;
+        this.createdAt = Instant.now();
+    }
+
+    public void update(String title, String description, Horizon horizon) {
+        this.title = title;
+        this.description = description;
+        this.horizon = horizon;
+    }
+
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Horizon getHorizon() {
+        return horizon;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getDeletedAt() {
+        return deletedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Strategy strategy = (Strategy) o;
+        return Objects.equals(id, strategy.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyController.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyController.java
@@ -1,0 +1,63 @@
+package br.com.fiap.aguiabranca.domain.strategy;
+
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Assimetria proposital: leitura liberada para os tres perfis, escrita so para GESTOR e
+ * LIDERANCA. E o unico recurso do hub com essa regra — a #17 existe para que ela nao se perca
+ * numa refatoracao do SecurityConfig.
+ */
+@RestController
+@RequestMapping("/strategies")
+public class StrategyController {
+
+    private final StrategyService strategyService;
+
+    public StrategyController(StrategyService strategyService) {
+        this.strategyService = strategyService;
+    }
+
+    @GetMapping
+    public List<StrategyResponse> list() {
+        return strategyService.list().stream().map(StrategyResponse::from).toList();
+    }
+
+    @GetMapping("/{id}")
+    public StrategyResponse findById(@PathVariable Long id) {
+        return StrategyResponse.from(strategyService.findById(id));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('GESTOR', 'LIDERANCA')")
+    public ResponseEntity<StrategyResponse> create(@Valid @RequestBody StrategyRequest request) {
+        Strategy strategy = strategyService.create(request);
+        return ResponseEntity
+                .created(URI.create("/strategies/" + strategy.getId()))
+                .body(StrategyResponse.from(strategy));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('GESTOR', 'LIDERANCA')")
+    public StrategyResponse update(@PathVariable Long id, @Valid @RequestBody StrategyRequest request) {
+        return StrategyResponse.from(strategyService.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('GESTOR', 'LIDERANCA')")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        strategyService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyRepository.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyRepository.java
@@ -1,0 +1,11 @@
+package br.com.fiap.aguiabranca.domain.strategy;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StrategyRepository extends JpaRepository<Strategy, Long> {
+
+    List<Strategy> findAllByOrderByIdDesc();
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyRequest.java
@@ -1,0 +1,11 @@
+package br.com.fiap.aguiabranca.domain.strategy;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record StrategyRequest(
+        @NotBlank(message = "Título é obrigatório") @Size(max = 150, message = "Título tem no máximo 150 caracteres") String title,
+        @NotBlank(message = "Descrição é obrigatória") String description,
+        @NotNull(message = "Horizonte é obrigatório") Horizon horizon) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyResponse.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyResponse.java
@@ -1,0 +1,20 @@
+package br.com.fiap.aguiabranca.domain.strategy;
+
+import java.time.Instant;
+
+public record StrategyResponse(
+        Long id,
+        String title,
+        String description,
+        Horizon horizon,
+        Instant createdAt) {
+
+    public static StrategyResponse from(Strategy strategy) {
+        return new StrategyResponse(
+                strategy.getId(),
+                strategy.getTitle(),
+                strategy.getDescription(),
+                strategy.getHorizon(),
+                strategy.getCreatedAt());
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyService.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/strategy/StrategyService.java
@@ -1,0 +1,50 @@
+package br.com.fiap.aguiabranca.domain.strategy;
+
+import br.com.fiap.aguiabranca.shared.ErrorTypes;
+import br.com.fiap.aguiabranca.shared.ResourceNotFoundException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class StrategyService {
+
+    private final StrategyRepository strategies;
+
+    public StrategyService(StrategyRepository strategies) {
+        this.strategies = strategies;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Strategy> list() {
+        return strategies.findAllByOrderByIdDesc();
+    }
+
+    @Transactional(readOnly = true)
+    public Strategy findById(Long id) {
+        return strategies.findById(id).orElseThrow(() -> notFound(id));
+    }
+
+    @Transactional
+    public Strategy create(StrategyRequest request) {
+        return strategies.save(new Strategy(request.title(), request.description(), request.horizon()));
+    }
+
+    @Transactional
+    public Strategy update(Long id, StrategyRequest request) {
+        Strategy strategy = strategies.findById(id).orElseThrow(() -> notFound(id));
+        strategy.update(request.title(), request.description(), request.horizon());
+        return strategy;
+    }
+
+    /** Soft delete: marca deleted_at. O @SQLRestriction tira a linha das leituras seguintes. */
+    @Transactional
+    public void delete(Long id) {
+        strategies.findById(id).orElseThrow(() -> notFound(id)).softDelete();
+    }
+
+    private ResourceNotFoundException notFound(Long id) {
+        return new ResourceNotFoundException(ErrorTypes.STRATEGY_NOT_FOUND,
+                "Estratégia " + id + " não encontrada.");
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/user/Role.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/user/Role.java
@@ -1,0 +1,18 @@
+package br.com.fiap.aguiabranca.domain.user;
+
+/**
+ * Os tres perfis do hub.
+ *
+ * OPERADOR submete ideia e acompanha o que e seu; GESTOR revisa e toca projeto;
+ * LIDERANCA enxerga tudo e define estrategia.
+ */
+public enum Role {
+    OPERADOR,
+    GESTOR,
+    LIDERANCA;
+
+    /** O Spring Security espera a autoridade com prefixo ROLE_ para hasRole() funcionar. */
+    public String authority() {
+        return "ROLE_" + name();
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/user/User.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/user/User.java
@@ -1,0 +1,87 @@
+package br.com.fiap.aguiabranca.domain.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    protected User() {
+    }
+
+    public User(String name, String email, String passwordHash, Role role) {
+        this.name = name;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.role = role;
+        this.createdAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        User user = (User) o;
+        return id != null && Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/user/UserRepository.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/user/UserRepository.java
@@ -1,0 +1,11 @@
+package br.com.fiap.aguiabranca.domain.user;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/br/com/fiap/aguiabranca/shared/DomainRuleException.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/DomainRuleException.java
@@ -1,0 +1,23 @@
+package br.com.fiap.aguiabranca.shared;
+
+/**
+ * Regra de negocio violada — vira 422.
+ *
+ * Estende IllegalArgumentException de proposito: as entidades ja lancavam
+ * IllegalArgumentException e os testes de dominio afirmam sobre esse tipo. Herdar mantem
+ * esses testes validos e ainda permite ao handler distinguir "regra do dominio" de
+ * "argumento invalido qualquer".
+ */
+public class DomainRuleException extends IllegalArgumentException {
+
+    private final String type;
+
+    public DomainRuleException(String type, String message) {
+        super(message);
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/shared/ErrorTypes.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/ErrorTypes.java
@@ -1,0 +1,34 @@
+package br.com.fiap.aguiabranca.shared;
+
+import java.net.URI;
+
+/**
+ * URIs de "type" do RFC 7807.
+ *
+ * O cliente decide comportamento pelo type, nunca pelo title — title e texto livre e muda
+ * sem aviso. Por isso estes valores sao contrato: mudar um quebra o app.
+ */
+public final class ErrorTypes {
+
+    private static final String BASE = "https://aguiabranca.fiap.br/errors/";
+
+    public static final String VALIDATION = BASE + "validacao";
+    public static final String IDEA_NOT_FOUND = BASE + "ideia-nao-encontrada";
+    public static final String IDEA_ALREADY_REVIEWED = BASE + "ideia-ja-revisada";
+    public static final String IDEA_NOT_APPROVED = BASE + "ideia-nao-aprovada";
+    public static final String IDEA_ALREADY_PROMOTED = BASE + "ideia-ja-promovida";
+    public static final String PROJECT_NOT_FOUND = BASE + "projeto-nao-encontrado";
+    public static final String PROJECT_INVALID_PROGRESS = BASE + "progresso-invalido";
+    public static final String PROJECT_NO_METRIC = BASE + "nenhuma-metrica-informada";
+    public static final String STRATEGY_NOT_FOUND = BASE + "estrategia-nao-encontrada";
+    public static final String INVALID_CREDENTIALS = BASE + "credenciais-invalidas";
+    public static final String UNAUTHENTICATED = BASE + "nao-autenticado";
+    public static final String FORBIDDEN = BASE + "sem-permissao";
+
+    public static URI of(String type) {
+        return URI.create(type);
+    }
+
+    private ErrorTypes() {
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
@@ -1,0 +1,92 @@
+package br.com.fiap.aguiabranca.shared;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+/**
+ * Traduz excecao em RFC 7807.
+ *
+ * AccessDeniedException NAO e tratada aqui de proposito: ela precisa subir ate o
+ * ExceptionTranslationFilter do Spring Security, que e quem sabe diferenciar "nao sei quem
+ * voce e" (401) de "sei e voce nao pode" (403). Capturar aqui devolveria 403 tambem para
+ * requisicao anonima, e o app trataria sessao valida como expirada.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ProblemDetail handleNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
+        return problem(HttpStatus.NOT_FOUND, "Recurso nao encontrado", ex.getType(), ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(DomainRuleException.class)
+    public ProblemDetail handleDomainRule(DomainRuleException ex, HttpServletRequest request) {
+        return problem(HttpStatus.UNPROCESSABLE_ENTITY, "Regra de negocio violada", ex.getType(),
+                ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ProblemDetail handleBadCredentials(BadCredentialsException ex, HttpServletRequest request) {
+        // Mensagem deliberadamente igual para e-mail inexistente e senha errada: distinguir
+        // as duas entrega ao atacante uma lista de contas validas.
+        return problem(HttpStatus.UNAUTHORIZED, "Credenciais invalidas", ErrorTypes.INVALID_CREDENTIALS,
+                "E-mail ou senha incorretos.", request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+            HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        // 422 e nao 400: o corpo chegou bem-formado, o que falhou foi a regra do campo.
+        // A #25 conta com essa distincao para escolher a mensagem no app.
+        ProblemDetail detail = ProblemDetail.forStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+        detail.setType(ErrorTypes.of(ErrorTypes.VALIDATION));
+        detail.setTitle("Payload invalido");
+        detail.setDetail("Um ou mais campos nao passaram na validacao.");
+
+        Map<String, String> fields = new TreeMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            fields.put(error.getField(), error.getDefaultMessage());
+        }
+        detail.setProperty("errors", fields);
+
+        return ResponseEntity.unprocessableEntity().body(detail);
+    }
+
+    private ProblemDetail problem(HttpStatus status, String title, String type, String message,
+            HttpServletRequest request) {
+        ProblemDetail detail = ProblemDetail.forStatus(status);
+        detail.setType(ErrorTypes.of(type));
+        detail.setTitle(title);
+        detail.setDetail(message);
+        detail.setInstance(URI.create(request.getRequestURI()));
+        return detail;
+    }
+
+    /** Usado tambem pelos handlers da cadeia de filtros, que respondem fora do MVC. */
+    public static Map<String, Object> asMap(HttpStatus status, String type, String title, String detail,
+            String instance) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("type", type);
+        body.put("title", title);
+        body.put("status", status.value());
+        body.put("detail", detail);
+        body.put("instance", instance);
+        return body;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package br.com.fiap.aguiabranca.shared;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -29,13 +31,19 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(ResourceNotFoundException.class)
     public ProblemDetail handleNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
+        log.debug("404 em {}: {}", request.getRequestURI(), ex.getMessage());
         return problem(HttpStatus.NOT_FOUND, "Recurso nao encontrado", ex.getType(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(DomainRuleException.class)
     public ProblemDetail handleDomainRule(DomainRuleException ex, HttpServletRequest request) {
+        // WARN e nao ERROR: regra de negocio recusada e funcionamento esperado, nao falha da app.
+        // Sai correlacionado pelo MDC, entao da para reconstruir a requisicao inteira pelo ID.
+        log.warn("422 em {} ({}): {}", request.getRequestURI(), ex.getType(), ex.getMessage());
         return problem(HttpStatus.UNPROCESSABLE_ENTITY, "Regra de negocio violada", ex.getType(),
                 ex.getMessage(), request);
     }
@@ -64,6 +72,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             fields.put(error.getField(), error.getDefaultMessage());
         }
         detail.setProperty("errors", fields);
+        if (request instanceof org.springframework.web.context.request.ServletWebRequest servletRequest) {
+            detail.setInstance(instanceOf(servletRequest.getRequest()));
+        }
 
         return ResponseEntity.unprocessableEntity().body(detail);
     }
@@ -74,8 +85,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         detail.setType(ErrorTypes.of(type));
         detail.setTitle(title);
         detail.setDetail(message);
-        detail.setInstance(URI.create(request.getRequestURI()));
+        detail.setInstance(instanceOf(request));
         return detail;
+    }
+
+    /**
+     * O instance aponta para a ocorrencia, nao para o recurso: com o correlation ID ali, um
+     * print de tela do erro basta para achar as linhas de log daquela requisicao exata.
+     */
+    public static URI instanceOf(HttpServletRequest request) {
+        String requestId = RequestId.current();
+        return requestId == null
+                ? URI.create(request.getRequestURI())
+                : URI.create("urn:request-id:" + requestId);
     }
 
     /** Usado tambem pelos handlers da cadeia de filtros, que respondem fora do MVC. */

--- a/src/main/java/br/com/fiap/aguiabranca/shared/RequestId.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/RequestId.java
@@ -1,0 +1,17 @@
+package br.com.fiap.aguiabranca.shared;
+
+import org.slf4j.MDC;
+
+/** Acesso ao correlation ID da requisicao corrente. */
+public final class RequestId {
+
+    public static final String HEADER = "X-Request-Id";
+    public static final String MDC_KEY = "requestId";
+
+    public static String current() {
+        return MDC.get(MDC_KEY);
+    }
+
+    private RequestId() {
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/shared/RequestIdFilter.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/RequestIdFilter.java
@@ -1,0 +1,58 @@
+package br.com.fiap.aguiabranca.shared;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Amarra todas as linhas de log de uma requisicao a um mesmo identificador.
+ *
+ * Ordem mais alta possivel de proposito: precisa envolver tambem a cadeia do Spring Security,
+ * senao falha de autenticacao — justamente o que mais se investiga — sai sem correlacao.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain chain) throws ServletException, IOException {
+
+        String requestId = resolve(request.getHeader(RequestId.HEADER));
+        MDC.put(RequestId.MDC_KEY, requestId);
+        // Escrito antes de seguir a cadeia: depois que a resposta e comitada, header nao entra mais.
+        response.setHeader(RequestId.HEADER, requestId);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            // Nao e opcional: o Tomcat reusa threads do pool e, sem a limpeza, a proxima
+            // requisicao que cair nesta thread herda o ID da anterior. E um bug que so
+            // aparece sob carga e faz a investigacao apontar para a requisicao errada.
+            MDC.remove(RequestId.MDC_KEY);
+        }
+    }
+
+    /**
+     * Valor recebido do cliente e aceito, mas nao em qualquer formato: ele entra no log, e
+     * cabecalho e entrada do usuario. Um valor arbitrario de 8 KB polui todas as linhas.
+     */
+    private String resolve(String received) {
+        if (received == null || received.length() > 64) {
+            return UUID.randomUUID().toString();
+        }
+        String sanitized = received.replaceAll("[^A-Za-z0-9_.:-]", "");
+        // Sobrou vazio: o header veio so com caracteres que a limpeza descarta. Deixar assim
+        // poria um ID em branco no MDC, e a linha de log ficaria igual a de quem nao tem
+        // correlacao nenhuma — pior do que gerar um valor novo.
+        return sanitized.isBlank() ? UUID.randomUUID().toString() : sanitized;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/shared/ResourceNotFoundException.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/ResourceNotFoundException.java
@@ -1,0 +1,16 @@
+package br.com.fiap.aguiabranca.shared;
+
+/** Recurso inexistente, ou existente e invisivel para quem pediu — vira 404. */
+public class ResourceNotFoundException extends RuntimeException {
+
+    private final String type;
+
+    public ResourceNotFoundException(String type, String message) {
+        super(message);
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,16 @@
+# Profile de desenvolvimento. O segredo abaixo e publico por definicao — esta versionado.
+# O JwtSecretGuard recusa o boot se ele aparecer com qualquer profile que nao seja dev.
+spring:
+  flyway:
+    locations: classpath:db/migration,classpath:db/seed
+    # O seed e a versao 9000. Sem out-of-order, uma V3 nova de producao seria recusada em dev
+    # ("out of order") por ter numero menor que algo ja aplicado.
+    out-of-order: true
+    # Banco de dev que aplicou o seed quando ele ainda era a V2 tem no historico uma versao
+    # que nao existe mais em lugar nenhum. Sem isto, o Flyway trava com "applied migration not
+    # resolved locally" e o unico caminho seria recriar o banco.
+    ignore-migration-patterns: "*:missing"
+
+app:
+  jwt:
+    secret: dev-secret-nao-use-em-producao-troque-me-agora

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,58 @@
+spring:
+  application:
+    name: fiap-aguia-branca
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/aguiabranca}
+    username: ${DB_USERNAME:aguiabranca}
+    password: ${DB_PASSWORD:aguiabranca}
+
+  jpa:
+    # O schema e dono do Flyway. validate falha o boot se a entidade divergir da migration,
+    # que e exatamente o alarme que se quer: divergencia descoberta no deploy, nao em runtime.
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+
+  flyway:
+    enabled: true
+    # Somente db/migration. O seed de desenvolvimento vive em db/seed e so entra pelo
+    # profile dev — assim producao nao ganha contas com senha conhecida por construcao,
+    # e nao por alguem lembrar de apagar a linha depois.
+    locations: classpath:db/migration
+
+app:
+  cors:
+    # Vazio por default: nenhuma origem cross-origin passa sem configuracao explicita.
+    # O cliente atual e o app Android, que nao e afetado por CORS — isto fica pronto e
+    # desligado, esperando um front web existir.
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
+  jwt:
+    # Sem default: a aplicacao nao sobe sem JWT_SECRET no ambiente. Para desenvolvimento,
+    # o valor vem do profile dev (application-dev.yml), nunca daqui.
+    secret: ${JWT_SECRET:}
+    # TODO(#8): 8h sem renovacao — o app derruba o usuario no meio do uso quando expira.
+    expiration: PT8H
+
+management:
+  endpoints:
+    web:
+      exposure:
+        # Explicito de proposito. O default do Actuator ja e este, mas escrever aqui
+        # transforma "expor /actuator/env para depurar" numa mudanca visivel no diff —
+        # /actuator/env entrega variaveis de ambiente, incluindo o JWT_SECRET da #6.
+        include: health,info
+  endpoint:
+    health:
+      # Detalhe (inclusive o status do Postgres) so para quem esta autenticado.
+      # A rota e publica para o healthcheck do Docker, mas o corpo publico e so {"status":"UP"}.
+      show-details: when-authorized
+
+logging:
+  level:
+    org.flywaydb: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,5 +54,9 @@ management:
       show-details: when-authorized
 
 logging:
+  # Injeta o correlation ID no campo de nivel do padrao default do Boot, em vez de reescrever
+  # o padrao inteiro — assim cor, timestamp e thread continuam vindo do Spring Boot.
+  pattern:
+    level: "%5p [%X{requestId:-sem-request-id}]"
   level:
     org.flywaydb: INFO

--- a/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,74 @@
+-- Schema inicial do Hub de Inovacao.
+-- Todo dinheiro e NUMERIC(15,2): ponto flutuante em valor financeiro acumula erro de
+-- arredondamento que aparece como centavo perdido no fechamento.
+
+CREATE TABLE users (
+    id            BIGSERIAL PRIMARY KEY,
+    name          VARCHAR(120) NOT NULL,
+    email         VARCHAR(180) NOT NULL UNIQUE,
+    password_hash VARCHAR(100) NOT NULL,
+    role          VARCHAR(20)  NOT NULL,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT ck_users_role CHECK (role IN ('OPERADOR', 'GESTOR', 'LIDERANCA'))
+);
+
+CREATE TABLE ideas (
+    id             BIGSERIAL PRIMARY KEY,
+    title          VARCHAR(150) NOT NULL,
+    description    TEXT         NOT NULL,
+    status         VARCHAR(20)  NOT NULL,
+    owner_id       BIGINT       NOT NULL REFERENCES users (id),
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    reviewed_by_id BIGINT       REFERENCES users (id),
+    reviewed_at    TIMESTAMPTZ,
+    CONSTRAINT ck_ideas_status CHECK (status IN ('DRAFT', 'IN_REVIEW', 'APPROVED', 'REJECTED'))
+);
+
+-- A listagem do app filtra por status e o OPERADOR so enxerga as proprias ideias:
+-- os dois indices cobrem os dois caminhos de leitura da tela inicial.
+CREATE INDEX idx_ideas_status ON ideas (status);
+CREATE INDEX idx_ideas_owner ON ideas (owner_id);
+
+CREATE TABLE projects (
+    id         BIGSERIAL PRIMARY KEY,
+    name       VARCHAR(150)   NOT NULL,
+    status     VARCHAR(20)    NOT NULL,
+    progress   INTEGER        NOT NULL DEFAULT 0,
+    budget     NUMERIC(15, 2) NOT NULL,
+    spent      NUMERIC(15, 2) NOT NULL DEFAULT 0,
+    -- UNIQUE e o que impede promover a mesma ideia duas vezes mesmo sob corrida:
+    -- a checagem no service perde para duas requisicoes simultaneas, a constraint nao.
+    idea_id    BIGINT         UNIQUE REFERENCES ideas (id),
+    created_at TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    CONSTRAINT ck_projects_status CHECK (status IN ('PLANNING', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED')),
+    CONSTRAINT ck_projects_progress CHECK (progress BETWEEN 0 AND 100)
+);
+
+CREATE INDEX idx_projects_status ON projects (status);
+
+CREATE TABLE project_metrics_history (
+    id            BIGSERIAL PRIMARY KEY,
+    project_id    BIGINT         NOT NULL REFERENCES projects (id),
+    metric        VARCHAR(30)    NOT NULL,
+    old_value     NUMERIC(15, 2),
+    new_value     NUMERIC(15, 2) NOT NULL,
+    changed_by_id BIGINT         NOT NULL REFERENCES users (id),
+    changed_at    TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    CONSTRAINT ck_metrics_metric CHECK (metric IN ('PROGRESS', 'SPENT'))
+);
+
+-- A auditoria e sempre lida como "historico deste projeto em ordem de tempo".
+CREATE INDEX idx_metrics_history_project ON project_metrics_history (project_id, changed_at);
+
+CREATE TABLE strategies (
+    id          BIGSERIAL PRIMARY KEY,
+    title       VARCHAR(150) NOT NULL,
+    description TEXT         NOT NULL,
+    horizon     VARCHAR(20)  NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    -- Soft delete: deleted_at preenchido marca excluido, a linha continua na tabela.
+    deleted_at  TIMESTAMPTZ,
+    CONSTRAINT ck_strategies_horizon CHECK (horizon IN ('SHORT', 'MEDIUM', 'LONG'))
+);
+
+CREATE INDEX idx_strategies_active ON strategies (deleted_at) WHERE deleted_at IS NULL;

--- a/src/main/resources/db/seed/V9000__seed_dev_data.sql
+++ b/src/main/resources/db/seed/V9000__seed_dev_data.sql
@@ -1,0 +1,47 @@
+-- Massa de desenvolvimento: um usuario por perfil e dados de exemplo para as telas.
+--
+-- Vive em db/seed, fora do location de producao. So o profile dev inclui esta pasta, entao
+-- em prod estas linhas nao existem e a versao nao aparece no flyway_schema_history.
+--
+-- A versao e 9000, nao 2, de proposito: o Flyway funde os dois locations numa sequencia unica
+-- de versoes. Com o seed em V2, a proxima migration real de producao tambem seria V2 e os dois
+-- ambientes divergiriam no mesmo numero. Numero alto mantem as duas faixas separadas.
+--
+-- Senhas: operador123 / gestor123 / lideranca123 (BCrypt custo 10).
+
+INSERT INTO users (name, email, password_hash, role) VALUES
+    ('Operador Dev',  'operador@aguiabranca.dev',  '$2a$10$pkEmGv/Da/3o9moj4JeQ5OZtm3Ctks2wCLsdcncBFZVHNMo5E9AOq', 'OPERADOR'),
+    ('Operadora Dev', 'operadora@aguiabranca.dev', '$2a$10$pkEmGv/Da/3o9moj4JeQ5OZtm3Ctks2wCLsdcncBFZVHNMo5E9AOq', 'OPERADOR'),
+    ('Gestor Dev',    'gestor@aguiabranca.dev',    '$2a$10$6heaHXMXLtD8PxBrF4sNeeOgvYKOn2gSUh.DfDoadMLOmXeFIz1Du', 'GESTOR'),
+    ('Lideranca Dev', 'lideranca@aguiabranca.dev', '$2a$10$M.ZV/ZbIR8qecgGk8nNYhOBgX0qArczlOfjaN3GTRh4qOY02neiHW', 'LIDERANCA');
+
+INSERT INTO ideas (title, description, status, owner_id) VALUES
+    ('Rastreamento de frota em tempo real',
+     'Telemetria embarcada para acompanhar posicao e consumo da frota durante a rota.',
+     'APPROVED',
+     (SELECT id FROM users WHERE email = 'operador@aguiabranca.dev')),
+    ('Portal de autoatendimento do cliente',
+     'Consulta de coletas, segunda via de nota e abertura de ocorrencia sem passar pelo SAC.',
+     'IN_REVIEW',
+     (SELECT id FROM users WHERE email = 'operador@aguiabranca.dev')),
+    ('Roteirizacao dinamica de entregas',
+     'Recalcular rota conforme transito e janela de entrega, em vez de rota fixa do dia anterior.',
+     'DRAFT',
+     (SELECT id FROM users WHERE email = 'operadora@aguiabranca.dev'));
+
+INSERT INTO projects (name, status, progress, budget, spent, idea_id) VALUES
+    ('Rastreamento de frota em tempo real', 'IN_PROGRESS', 35, 850000.00, 297500.00,
+     (SELECT id FROM ideas WHERE title = 'Rastreamento de frota em tempo real')),
+    ('Modernizacao do centro de distribuicao', 'PLANNING', 0, 1200000.00, 0.00, NULL),
+    ('Digitalizacao de canhotos', 'COMPLETED', 100, 180000.00, 172400.00, NULL);
+
+INSERT INTO strategies (title, description, horizon) VALUES
+    ('Reduzir custo por quilometro rodado',
+     'Meta de queda de 8% no custo por km ate o fim do ciclo, via telemetria e roteirizacao.',
+     'MEDIUM'),
+    ('Elevar indice de entrega no prazo',
+     'Chegar a 97% de entregas dentro da janela combinada com o cliente.',
+     'SHORT'),
+    ('Eletrificar a frota urbana',
+     'Substituir gradualmente a frota leve urbana por veiculos eletricos.',
+     'LONG');

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/ActuatorIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/ActuatorIntegrationTest.java
@@ -1,0 +1,52 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ActuatorIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("Health responde 200 sem autenticacao")
+    void shouldExposeHealthWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    @DisplayName("Health anonimo nao vaza detalhe de infraestrutura")
+    void shouldHideDetailsFromAnonymous() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.components").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("Health autenticado mostra o status do Postgres")
+    void shouldShowDatabaseStatusWhenAuthorized() throws Exception {
+        String token = tokenFor("gestor-actuator@teste.dev", Role.GESTOR);
+
+        mockMvc.perform(get("/actuator/health").header("Authorization", bearer(token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.components.db.status").value("UP"));
+    }
+
+    @Test
+    @DisplayName("Endpoints fora de health e info nao existem, nem com token")
+    void shouldNotExposeOtherEndpoints() throws Exception {
+        String token = tokenFor("lideranca-actuator@teste.dev", Role.LIDERANCA);
+
+        // /actuator/env entregaria as variaveis de ambiente, JWT_SECRET incluso.
+        mockMvc.perform(get("/actuator/env").header("Authorization", bearer(token)))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(get("/actuator/beans").header("Authorization", bearer(token)))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
@@ -1,0 +1,100 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthFlowIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("Login valido devolve access token com o perfil do usuario")
+    void shouldReturnTokenOnValidLogin() throws Exception {
+        givenUser("gestor@teste.dev", "senha-forte-123", Role.GESTOR);
+
+        mockMvc.perform(post("/auth/login")
+                .contentType("application/json")
+                .content("""
+                        {"email": "gestor@teste.dev", "password": "senha-forte-123"}
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.role").value("GESTOR"))
+                .andExpect(jsonPath("$.expiresIn").isNumber());
+    }
+
+    @Test
+    @DisplayName("Senha errada e e-mail inexistente respondem 401 com a mesma mensagem")
+    void shouldNotRevealWhetherAccountExists() throws Exception {
+        givenUser("existe@teste.dev", "senha-forte-123", Role.OPERADOR);
+
+        String wrongPassword = mockMvc.perform(post("/auth/login")
+                .contentType("application/json")
+                .content("""
+                        {"email": "existe@teste.dev", "password": "senha-errada-123"}
+                        """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/credenciais-invalidas"))
+                .andReturn().getResponse().getContentAsString();
+
+        String unknownAccount = mockMvc.perform(post("/auth/login")
+                .contentType("application/json")
+                .content("""
+                        {"email": "naoexiste@teste.dev", "password": "senha-errada-123"}
+                        """))
+                .andExpect(status().isUnauthorized())
+                .andReturn().getResponse().getContentAsString();
+
+        // Se as duas respostas diferissem, daria para enumerar contas validas so pelo corpo.
+        org.junit.jupiter.api.Assertions.assertEquals(wrongPassword, unknownAccount);
+    }
+
+    @Test
+    @DisplayName("Rota protegida sem token responde 401 em ProblemDetail")
+    void shouldRejectRequestWithoutToken() throws Exception {
+        mockMvc.perform(get("/ideas"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/nao-autenticado"))
+                .andExpect(jsonPath("$.status").value(401));
+    }
+
+    @Test
+    @DisplayName("Token com assinatura invalida responde 401, nao 403")
+    void shouldRejectTamperedToken() throws Exception {
+        String token = tokenFor("operador@teste.dev", Role.OPERADOR);
+        String tampered = token.substring(0, token.lastIndexOf('.') + 1) + "assinaturaForjada";
+
+        mockMvc.perform(get("/ideas").header("Authorization", bearer(tampered)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Token valido acessa rota protegida")
+    void shouldAcceptValidToken() throws Exception {
+        String token = tokenFor("valido@teste.dev", Role.OPERADOR);
+
+        mockMvc.perform(get("/ideas").header("Authorization", bearer(token)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Resposta de erro nao devolve o hash da senha nem o segredo do token")
+    void shouldNotLeakSecrets() throws Exception {
+        givenUser("segredo@teste.dev", "senha-forte-123", Role.OPERADOR);
+
+        mockMvc.perform(post("/auth/login")
+                .contentType("application/json")
+                .content("""
+                        {"email": "segredo@teste.dev", "password": "errada"}
+                        """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.detail").value(not(containsString("$2a$"))));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
@@ -14,6 +14,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class AuthFlowIntegrationTest extends IntegrationTestSupport {
 
+    private String withoutInstance(String problemDetailJson) throws Exception {
+        var node = (com.fasterxml.jackson.databind.node.ObjectNode) objectMapper.readTree(problemDetailJson);
+        node.remove("instance");
+        return node.toString();
+    }
+
     @Test
     @DisplayName("Login valido devolve access token com o perfil do usuario")
     void shouldReturnTokenOnValidLogin() throws Exception {
@@ -53,7 +59,10 @@ class AuthFlowIntegrationTest extends IntegrationTestSupport {
                 .andReturn().getResponse().getContentAsString();
 
         // Se as duas respostas diferissem, daria para enumerar contas validas so pelo corpo.
-        org.junit.jupiter.api.Assertions.assertEquals(wrongPassword, unknownAccount);
+        // O instance fica de fora da comparacao: ele carrega o correlation ID da requisicao (#13),
+        // que e diferente a cada chamada por definicao e nao diz nada sobre a conta.
+        org.junit.jupiter.api.Assertions.assertEquals(
+                withoutInstance(wrongPassword), withoutInstance(unknownAccount));
     }
 
     @Test

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsDisabledIntegrationTest.java
@@ -1,0 +1,31 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+/**
+ * Configuracao default — nenhuma origem listada. Nada de cross-origin pode passar.
+ */
+class CorsDisabledIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("Sem origem configurada, o preflight nao recebe Allow-Origin")
+    void shouldNotAllowAnyOriginByDefault() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", "https://qualquer-um.example")
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Sem origem configurada, resposta normal tambem nao ganha Allow-Origin")
+    void shouldNotDecorateSimpleRequests() throws Exception {
+        mockMvc.perform(get("/ideas").header("Origin", "https://qualquer-um.example"))
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
@@ -1,0 +1,63 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = "app.cors.allowed-origins=https://hub.aguiabranca.dev")
+class CorsEnabledIntegrationTest extends IntegrationTestSupport {
+
+    private static final String ALLOWED = "https://hub.aguiabranca.dev";
+    private static final String DENIED = "https://site-qualquer.example";
+
+    @Test
+    @DisplayName("Preflight de origem permitida responde 200 com os headers corretos")
+    void shouldAllowConfiguredOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+    }
+
+    @Test
+    @DisplayName("Preflight de origem nao listada e recusado")
+    void shouldRejectUnknownOrigin() throws Exception {
+        mockMvc.perform(options("/ideas")
+                .header("Origin", DENIED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    @DisplayName("Authorization esta entre os headers permitidos")
+    void shouldAllowAuthorizationHeader() throws Exception {
+        // Sem isto o navegador barra o preflight e nenhuma chamada autenticada sai do front.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET")
+                .header("Access-Control-Request-Headers", "Authorization"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Headers", containsString("Authorization")));
+    }
+
+    @Test
+    @DisplayName("Com credenciais habilitadas, Allow-Origin nunca sai como curinga")
+    void shouldNeverEchoWildcardWithCredentials() throws Exception {
+        // "*" com allowCredentials e recusado pelo proprio Spring em runtime; o header tem
+        // que ecoar a origem que pediu.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "POST"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
@@ -50,6 +50,18 @@ class CorsEnabledIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
+    @DisplayName("X-Request-Id e exposto para o JavaScript conseguir ler")
+    void shouldExposeRequestIdHeader() throws Exception {
+        // Header de resposta nao exposto o navegador esconde do JS: o ID chegaria na resposta
+        // e o front nao conseguiria mostra-lo em tela para o usuario reportar.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Expose-Headers", containsString("X-Request-Id")));
+    }
+
+    @Test
     @DisplayName("Com credenciais habilitadas, Allow-Origin nunca sai como curinga")
     void shouldNeverEchoWildcardWithCredentials() throws Exception {
         // "*" com allowCredentials e recusado pelo proprio Spring em runtime; o header tem

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretValidationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretValidationTest.java
@@ -1,0 +1,105 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Valida o boot, nao o runtime: por isso ApplicationContextRunner em vez de @SpringBootTest.
+ * O que se afirma aqui e "o contexto NAO sobe", e subir a app inteira so para vê-la falhar
+ * custaria um Postgres por caso de teste.
+ */
+class JwtSecretValidationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of())
+            .withUserConfiguration(JwtTestConfiguration.class)
+            .withPropertyValues("app.jwt.expiration=PT8H");
+
+    @Test
+    @DisplayName("Sobe com segredo proprio de 32 bytes ou mais")
+    void shouldStartWithStrongSecret() {
+        runner.withPropertyValues("app.jwt.secret=um-segredo-bem-comprido-com-mais-de-32-bytes")
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    @DisplayName("Nao sobe com segredo menor que 32 bytes")
+    void shouldFailWhenSecretIsTooShort() {
+        runner.withPropertyValues("app.jwt.secret=curto-demais")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(rootMessage(context.getStartupFailure())).contains("12 bytes", "minimo para HS256");
+                });
+    }
+
+    @Test
+    @DisplayName("Nao sobe sem JWT_SECRET definida")
+    void shouldFailWhenSecretIsMissing() {
+        runner.withPropertyValues("app.jwt.secret=")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(rootMessage(context.getStartupFailure())).contains("JWT_SECRET nao definida");
+                });
+    }
+
+    @Test
+    @DisplayName("Nao sobe com o segredo de dev fora do profile dev")
+    void shouldRejectDevSecretOutsideDevProfile() {
+        runner.withPropertyValues("app.jwt.secret=" + JwtSecretGuard.DEV_SECRET)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(rootMessage(context.getStartupFailure()))
+                            .contains("valor de desenvolvimento");
+                });
+    }
+
+    @Test
+    @DisplayName("Aceita o segredo de dev quando o profile dev esta ativo")
+    void shouldAcceptDevSecretUnderDevProfile() {
+        runner.withPropertyValues("app.jwt.secret=" + JwtSecretGuard.DEV_SECRET)
+                .withSystemProperties("spring.profiles.active=dev")
+                .run(context -> assertThat(context).hasNotFailed());
+    }
+
+    @Test
+    @DisplayName("A mensagem de erro nunca imprime o valor do segredo")
+    void shouldNeverPrintTheSecretValue() {
+        String secret = "curto";
+
+        runner.withPropertyValues("app.jwt.secret=" + secret)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    // Mensagem de boot vai para log, e log vaza: ela informa o tamanho, nunca o valor.
+                    assertThat(fullTrace(context.getStartupFailure())).doesNotContain(secret);
+                });
+    }
+
+    private static String rootMessage(Throwable failure) {
+        Throwable root = failure;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        return String.valueOf(root.getMessage());
+    }
+
+    private static String fullTrace(Throwable failure) {
+        StringBuilder text = new StringBuilder();
+        for (Throwable current = failure; current != null; current = current.getCause()) {
+            text.append(current.getMessage()).append('\n');
+        }
+        return text.toString();
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(JwtProperties.class)
+    @Import(JwtSecretGuard.class)
+    static class JwtTestConfiguration {
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
@@ -1,0 +1,125 @@
+package br.com.fiap.aguiabranca.domain.user;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Prova que o seed nao alcanca producao.
+ *
+ * Roda o Flyway pela API Java em um banco novo por caso, em vez de subir o contexto do Spring:
+ * o que se afirma aqui e sobre a configuracao do Flyway, e dois contextos com locations
+ * diferentes brigando pelo mesmo banco dariam um teste que depende da ordem de execucao.
+ */
+class SeedMigrationIsolationTest {
+
+    private static final String PRODUCTION_LOCATIONS = "classpath:db/migration";
+    private static final String DEVELOPMENT_LOCATIONS = "classpath:db/migration,classpath:db/seed";
+
+    @Test
+    @DisplayName("Locations de producao nao criam nenhuma linha do seed")
+    void productionLocationsShouldNotApplySeed() throws SQLException {
+        String url = freshDatabase("prod_sem_seed");
+        migrate(url, PRODUCTION_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM users")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM ideas")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM projects")).isZero();
+        assertThat(count(url, "SELECT count(*) FROM strategies")).isZero();
+    }
+
+    @Test
+    @DisplayName("flyway_schema_history de producao nao contem a versao do seed")
+    void productionHistoryShouldNotContainSeedVersion() throws SQLException {
+        String url = freshDatabase("prod_historico");
+        migrate(url, PRODUCTION_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '9000'"))
+                .isZero();
+        // A V1 continua registrada: o schema real e o mesmo dos dois lados.
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '1'"))
+                .isOne();
+    }
+
+    @Test
+    @DisplayName("Locations de desenvolvimento continuam criando o seed")
+    void developmentLocationsShouldApplySeed() throws SQLException {
+        String url = freshDatabase("dev_com_seed");
+        migrate(url, DEVELOPMENT_LOCATIONS);
+
+        assertThat(count(url, "SELECT count(*) FROM users")).isEqualTo(4);
+        assertThat(count(url, "SELECT count(*) FROM users WHERE role = 'LIDERANCA'")).isOne();
+        assertThat(count(url, "SELECT count(*) FROM flyway_schema_history WHERE version = '9000'"))
+                .isOne();
+    }
+
+    @Test
+    @DisplayName("O schema aplicado e o mesmo nos dois ambientes — so o conteudo difere")
+    void schemaShouldBeIdenticalAcrossEnvironments() throws SQLException {
+        String production = freshDatabase("comparacao_prod");
+        String development = freshDatabase("comparacao_dev");
+        migrate(production, PRODUCTION_LOCATIONS);
+        migrate(development, DEVELOPMENT_LOCATIONS);
+
+        // Divergencia de schema entre ambientes e o que faz "funciona em dev" virar erro no deploy.
+        assertThat(tableNames(development)).isEqualTo(tableNames(production));
+    }
+
+    private static void migrate(String url, String locations) {
+        Flyway.configure()
+                .dataSource(url, IntegrationTestSupport.POSTGRES.getUsername(),
+                        IntegrationTestSupport.POSTGRES.getPassword())
+                .locations(locations.split(","))
+                .load()
+                .migrate();
+    }
+
+    /** CREATE DATABASE nao roda dentro de transacao — dai o Statement direto no autocommit. */
+    private static String freshDatabase(String name) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        try (Connection connection = DriverManager.getConnection(container.getJdbcUrl(),
+                container.getUsername(), container.getPassword());
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP DATABASE IF EXISTS " + name);
+            statement.execute("CREATE DATABASE " + name);
+        }
+        return "jdbc:postgresql://" + container.getHost() + ":" + container.getFirstMappedPort() + "/" + name;
+    }
+
+    private static long count(String url, String sql) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        try (Connection connection = DriverManager.getConnection(url, container.getUsername(),
+                container.getPassword());
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(sql)) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    private static String tableNames(String url) throws SQLException {
+        var container = IntegrationTestSupport.POSTGRES;
+        StringBuilder names = new StringBuilder();
+        try (Connection connection = DriverManager.getConnection(url, container.getUsername(),
+                container.getPassword());
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("""
+                        SELECT table_name FROM information_schema.tables
+                        WHERE table_schema = 'public' AND table_name <> 'flyway_schema_history'
+                        ORDER BY table_name
+                        """)) {
+            while (rs.next()) {
+                names.append(rs.getString(1)).append(',');
+            }
+        }
+        return names.toString();
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/shared/RequestIdIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/shared/RequestIdIntegrationTest.java
@@ -1,0 +1,155 @@
+package br.com.fiap.aguiabranca.shared;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RequestIdIntegrationTest extends IntegrationTestSupport {
+
+    private ListAppender<ILoggingEvent> logs;
+    private ch.qos.logback.classic.Logger handlerLogger;
+
+    @BeforeEach
+    void captureLogs() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        handlerLogger = context.getLogger(GlobalExceptionHandler.class);
+        logs = new ListAppender<>();
+        logs.setContext(context);
+        logs.start();
+        handlerLogger.addAppender(logs);
+        handlerLogger.setLevel(Level.DEBUG);
+    }
+
+    @AfterEach
+    void releaseLogs() {
+        handlerLogger.detachAppender(logs);
+    }
+
+    @Test
+    @DisplayName("Usa o X-Request-Id recebido quando o cliente manda um")
+    void shouldReuseIncomingRequestId() throws Exception {
+        String incoming = "app-android-abc-123";
+
+        mockMvc.perform(get("/actuator/health").header(RequestId.HEADER, incoming))
+                .andExpect(status().isOk())
+                .andExpect(header().string(RequestId.HEADER, incoming));
+    }
+
+    @Test
+    @DisplayName("Gera um UUID quando o header nao vem")
+    void shouldGenerateRequestIdWhenAbsent() throws Exception {
+        String generated = mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(RequestId.HEADER))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        assertThat(generated).isNotNull().matches("[0-9a-f-]{36}");
+    }
+
+    @Test
+    @DisplayName("Header absurdamente longo e descartado em favor de um UUID")
+    void shouldRejectOversizedIncomingId() throws Exception {
+        // Cabecalho e entrada do usuario, e este valor entra em toda linha de log.
+        String abusive = "x".repeat(5000);
+
+        String applied = mockMvc.perform(get("/actuator/health").header(RequestId.HEADER, abusive))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        assertThat(applied).isNotEqualTo(abusive).matches("[0-9a-f-]{36}");
+    }
+
+    @Test
+    @DisplayName("Caracteres de controle sao removidos do ID recebido")
+    void shouldStripControlCharactersFromIncomingId() throws Exception {
+        // O ID vai para dentro da linha de log: um \n vindo do cliente forjaria uma linha
+        // inteira de log falsa, e o valor ainda voltaria no header da resposta.
+        String applied = mockMvc.perform(get("/actuator/health")
+                .header(RequestId.HEADER, "app-android\r\nFATAL linha-forjada"))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        assertThat(applied).isEqualTo("app-androidFATALlinha-forjada");
+    }
+
+    @Test
+    @DisplayName("ID que some inteiro na limpeza vira um UUID, nunca vazio")
+    void shouldFallBackWhenSanitizationEmptiesTheId() throws Exception {
+        String applied = mockMvc.perform(get("/actuator/health")
+                .header(RequestId.HEADER, "@@@ ### $$$"))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        // ID em branco no MDC sai no log identico a uma requisicao sem correlacao alguma.
+        assertThat(applied).matches("[0-9a-f-]{36}");
+    }
+
+    @Test
+    @DisplayName("O MDC fica limpo depois da requisicao")
+    void shouldClearMdcAfterRequest() throws Exception {
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+
+        // O Tomcat reusa threads: sem a limpeza, a proxima requisicao nesta thread herdaria o ID.
+        assertThat(MDC.get(RequestId.MDC_KEY)).isNull();
+    }
+
+    @Test
+    @DisplayName("O instance do ProblemDetail carrega o mesmo ID da resposta")
+    void shouldCarryRequestIdInProblemDetailInstance() throws Exception {
+        String token = tokenFor("gestor-reqid@teste.dev", Role.GESTOR);
+        String incoming = "correlacao-de-teste-1";
+
+        mockMvc.perform(patch("/projects/999/metrics")
+                .header("Authorization", bearer(token))
+                .header(RequestId.HEADER, incoming)
+                .contentType("application/json")
+                .content("{}"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(header().string(RequestId.HEADER, incoming))
+                .andExpect(jsonPath("$.instance").value("urn:request-id:" + incoming));
+    }
+
+    @Test
+    @DisplayName("Resposta 401 tambem sai correlacionada, mesmo vindo de fora do MVC")
+    void shouldCorrelateUnauthenticatedResponses() throws Exception {
+        String incoming = "correlacao-sem-token";
+
+        // O 401 e escrito pelo entry point do Spring Security, fora do @RestControllerAdvice:
+        // se o filtro de ID nao envolvesse a cadeia de seguranca, esta resposta sairia sem ID.
+        mockMvc.perform(get("/ideas").header(RequestId.HEADER, incoming))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.instance").value("urn:request-id:" + incoming));
+    }
+
+    @Test
+    @DisplayName("As linhas de log do GlobalExceptionHandler saem com o ID no MDC")
+    void shouldCorrelateHandlerLogLines() throws Exception {
+        String token = tokenFor("gestor-log@teste.dev", Role.GESTOR);
+        String incoming = "correlacao-de-log-9";
+
+        mockMvc.perform(patch("/projects/999/metrics")
+                .header("Authorization", bearer(token))
+                .header(RequestId.HEADER, incoming)
+                .contentType("application/json")
+                .content("{}"))
+                .andExpect(status().isUnprocessableEntity());
+
+        assertThat(logs.list)
+                .isNotEmpty()
+                .allSatisfy(event -> assertThat(event.getMDCPropertyMap())
+                        .containsEntry(RequestId.MDC_KEY, incoming));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
+++ b/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
@@ -1,0 +1,105 @@
+package br.com.fiap.aguiabranca.support;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.domain.user.User;
+import br.com.fiap.aguiabranca.domain.user.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+/**
+ * Base dos testes de integracao.
+ *
+ * O container e um singleton estatico iniciado uma vez por JVM, nao um @Container por classe:
+ * com @Container cada classe de teste sobe e derruba o proprio Postgres, e a suite passa a
+ * levar minutos. O Ryuk do Testcontainers cuida de remover o container ao fim do processo.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+public abstract class IntegrationTestSupport {
+
+    public static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    protected UserRepository users;
+
+    @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    /**
+     * Cada teste comeca do zero, inclusive sem o seed da V2.
+     *
+     * Depender do seed acopla o teste a uma migration que a #7 vai justamente tirar do
+     * caminho de producao — e ai a suite quebraria por um motivo que nada tem a ver com
+     * o que ela testa.
+     */
+    @BeforeEach
+    void resetDatabase() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE project_metrics_history, projects, ideas, strategies, users
+                RESTART IDENTITY CASCADE
+                """);
+    }
+
+    protected User givenUser(String email, String rawPassword, Role role) {
+        return users.save(new User(email, email, passwordEncoder.encode(rawPassword), role));
+    }
+
+    /** Devolve o access token de um usuario recem-criado com o perfil pedido. */
+    protected String tokenFor(String email, Role role) throws Exception {
+        String password = "senha-de-teste-123";
+        givenUser(email, password, role);
+        return login(email, password);
+    }
+
+    protected String login(String email, String password) throws Exception {
+        String body = objectMapper.writeValueAsString(new LoginPayload(email, password));
+        String response = mockMvc.perform(post("/auth/login")
+                .contentType("application/json")
+                .content(body))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return objectMapper.readTree(response).path("accessToken").asText();
+    }
+
+    protected String bearer(String token) {
+        return "Bearer " + token;
+    }
+
+    protected record LoginPayload(String email, String password) {
+    }
+}

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -1,0 +1,6 @@
+# Perfil dos testes de integracao: schema vem do Flyway, como em producao.
+# O application.properties de teste desliga o Flyway para os slices @DataJpaTest; aqui
+# religa, porque o objetivo oposto — provar que migration e entidade nao divergiram.
+spring.flyway.enabled=true
+spring.jpa.hibernate.ddl-auto=validate
+app.jwt.secret=segredo-de-teste-com-mais-de-32-bytes-para-hs256

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 spring.flyway.enabled=false
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## O que muda

Leva para a `main` o stack inteiro que estava empilhado e nunca desceu. Os PRs #33 a #37 foram
mergeados em cadeia — cada um na branch do anterior, o mais externo primeiro — então tudo
colapsou aqui, na ponta de `chore/ci-workflow`, e a `main` ficou só com o workflow de CI.

Este PR não escreve código novo: é o degrau que faltava para o trabalho já revisado sair do
limbo. Nenhuma linha muda em relação ao que foi aprovado nos cinco PRs.

| Já revisado em | O que entra |
|---|---|
| #33 | Camada web, segurança e schema — as quatro fatias com controller, service, repository e DTOs; Flyway |
| #34 | Actuator com health detalhando o Postgres |
| #35 | `JWT_SECRET` só por variável de ambiente, com recusa de boot em segredo fraco |
| #36 | Seed de desenvolvimento fora do caminho de produção |
| #37 | CORS configurável por ambiente, desligado por default |

Closes #32
Closes #11
Closes #6
Closes #7
Closes #10

### Por que as issues ainda estavam abertas

`Closes #N` só fecha a issue quando o merge cai na branch **default**. Como cada PR do stack
mergeou numa branch intermediária, os cinco `Closes` não dispararam — e os cards ficaram parados
em `Em revisão` no board mesmo com o trabalho pronto. Este merge resolve os cinco de uma vez.

## Como validar

```
git checkout chore/ci-workflow
./mvnw -B clean verify
```

`Tests run: 33, Failures: 0, Errors: 0, Skipped: 0` — rodado nesta branch, nao herdado do #37.

Diff contra a `main`: 61 arquivos, +2569 / -5. Nada aqui é inédito — o conteúdo é exatamente o
das aprovações de #33 a #37. Para conferir isso sem reler tudo:

```
git diff origin/chore/cors-por-ambiente origin/chore/ci-workflow   # vazio: mesmo conteudo
```

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff — o segredo de `dev` é público de propósito e está documentado no README
- [x] Migration nova é idempotente e não roda em produção sem querer — o seed `V9000` só entra com o profile `dev` (#7)
- [x] Mudança de contrato de API está refletida no `README.md` — a tabela de rotas entrou junto em #33
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta — n/a, o app ainda consome o mock (#26)

## Risco

Baixo em revisão, alto em volume: nada foi revisado agora, mas nada foi escrito agora também.
O risco real é a `main` sair de um estado quase vazio para a aplicação inteira num único squash —
se algo estourar, o rollback é reverter este commit e a `main` volta ao estado atual.

O nome da branch (`chore/ci-workflow`) não descreve mais o que ela carrega: ela foi o degrau de
baixo do stack e acabou acumulando tudo. Some no squash.
