### PR TITLE
chore(logs): correlaciona log e resposta por X-Request-Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ curl -s localhost:8080/auth/login -H 'Content-Type: application/json' \
 Erro sai em RFC 7807. O campo estável para o cliente decidir comportamento é o **`type`**, nunca
 o `title` — que é texto livre e muda.
 
+### Correlation ID
+
+Toda resposta volta com o header **`X-Request-Id`**, e toda linha de log da requisição sai com o
+mesmo valor entre colchetes. Se o cliente mandar o header, ele é reaproveitado; se não mandar, a
+API gera um UUID.
+
+```
+2026-08-27T10:12:03.914-03:00  WARN [app-android-7f3a] 1 --- [nio-8080-exec-2] G.ExceptionHandler : 422 em /projects/12/metrics ...
+```
+
+Em resposta de erro o mesmo ID aparece no `instance` do ProblemDetail, como
+`urn:request-id:<id>` — então um print de tela do erro basta para achar as linhas de log daquela
+requisição exata, sem caçar por horário.
+
+Valor recebido do cliente é limpo antes de entrar no log: acima de 64 caracteres, ou sobrando
+vazio depois da limpeza, a API descarta e gera o próprio.
+
 ---
 
 ## Índice

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -2,6 +2,7 @@ package br.com.fiap.aguiabranca.domain.auth;
 
 import br.com.fiap.aguiabranca.shared.ErrorTypes;
 import br.com.fiap.aguiabranca.shared.GlobalExceptionHandler;
+import br.com.fiap.aguiabranca.shared.RequestId;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -62,14 +63,16 @@ public class SecurityConfig {
     private void unauthenticated(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.core.AuthenticationException ex) throws java.io.IOException {
         write(response, HttpStatus.UNAUTHORIZED, ErrorTypes.UNAUTHENTICATED, "Nao autenticado",
-                "Envie um token valido no header Authorization.", request.getRequestURI());
+                "Envie um token valido no header Authorization.",
+                GlobalExceptionHandler.instanceOf(request).toString());
     }
 
     /** Autenticado, mas sem o perfil exigido: 403. O app apenas informa, nao desloga. */
     private void forbidden(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.access.AccessDeniedException ex) throws java.io.IOException {
         write(response, HttpStatus.FORBIDDEN, ErrorTypes.FORBIDDEN, "Sem permissao",
-                "Seu perfil nao tem permissao para esta operacao.", request.getRequestURI());
+                "Seu perfil nao tem permissao para esta operacao.",
+                GlobalExceptionHandler.instanceOf(request).toString());
     }
 
     private void write(HttpServletResponse response, HttpStatus status, String type, String title,
@@ -97,7 +100,10 @@ public class SecurityConfig {
             // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
             configuration.setAllowedOrigins(corsProperties.allowedOrigins());
             configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Request-Id"));
+            configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", RequestId.HEADER));
+            // Exposto, e nao so permitido: header de resposta fora da lista branca do CORS o
+            // navegador esconde do JavaScript. O ID chegaria e o front nao conseguiria le-lo.
+            configuration.setExposedHeaders(List.of(RequestId.HEADER));
             configuration.setAllowCredentials(true);
             configuration.setMaxAge(Duration.ofHours(1));
             source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package br.com.fiap.aguiabranca.shared;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -29,13 +31,19 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(ResourceNotFoundException.class)
     public ProblemDetail handleNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
+        log.debug("404 em {}: {}", request.getRequestURI(), ex.getMessage());
         return problem(HttpStatus.NOT_FOUND, "Recurso nao encontrado", ex.getType(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(DomainRuleException.class)
     public ProblemDetail handleDomainRule(DomainRuleException ex, HttpServletRequest request) {
+        // WARN e nao ERROR: regra de negocio recusada e funcionamento esperado, nao falha da app.
+        // Sai correlacionado pelo MDC, entao da para reconstruir a requisicao inteira pelo ID.
+        log.warn("422 em {} ({}): {}", request.getRequestURI(), ex.getType(), ex.getMessage());
         return problem(HttpStatus.UNPROCESSABLE_ENTITY, "Regra de negocio violada", ex.getType(),
                 ex.getMessage(), request);
     }
@@ -64,6 +72,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             fields.put(error.getField(), error.getDefaultMessage());
         }
         detail.setProperty("errors", fields);
+        if (request instanceof org.springframework.web.context.request.ServletWebRequest servletRequest) {
+            detail.setInstance(instanceOf(servletRequest.getRequest()));
+        }
 
         return ResponseEntity.unprocessableEntity().body(detail);
     }
@@ -74,8 +85,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         detail.setType(ErrorTypes.of(type));
         detail.setTitle(title);
         detail.setDetail(message);
-        detail.setInstance(URI.create(request.getRequestURI()));
+        detail.setInstance(instanceOf(request));
         return detail;
+    }
+
+    /**
+     * O instance aponta para a ocorrencia, nao para o recurso: com o correlation ID ali, um
+     * print de tela do erro basta para achar as linhas de log daquela requisicao exata.
+     */
+    public static URI instanceOf(HttpServletRequest request) {
+        String requestId = RequestId.current();
+        return requestId == null
+                ? URI.create(request.getRequestURI())
+                : URI.create("urn:request-id:" + requestId);
     }
 
     /** Usado tambem pelos handlers da cadeia de filtros, que respondem fora do MVC. */

--- a/src/main/java/br/com/fiap/aguiabranca/shared/RequestId.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/RequestId.java
@@ -1,0 +1,17 @@
+package br.com.fiap.aguiabranca.shared;
+
+import org.slf4j.MDC;
+
+/** Acesso ao correlation ID da requisicao corrente. */
+public final class RequestId {
+
+    public static final String HEADER = "X-Request-Id";
+    public static final String MDC_KEY = "requestId";
+
+    public static String current() {
+        return MDC.get(MDC_KEY);
+    }
+
+    private RequestId() {
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/shared/RequestIdFilter.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/RequestIdFilter.java
@@ -1,0 +1,58 @@
+package br.com.fiap.aguiabranca.shared;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Amarra todas as linhas de log de uma requisicao a um mesmo identificador.
+ *
+ * Ordem mais alta possivel de proposito: precisa envolver tambem a cadeia do Spring Security,
+ * senao falha de autenticacao — justamente o que mais se investiga — sai sem correlacao.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain chain) throws ServletException, IOException {
+
+        String requestId = resolve(request.getHeader(RequestId.HEADER));
+        MDC.put(RequestId.MDC_KEY, requestId);
+        // Escrito antes de seguir a cadeia: depois que a resposta e comitada, header nao entra mais.
+        response.setHeader(RequestId.HEADER, requestId);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            // Nao e opcional: o Tomcat reusa threads do pool e, sem a limpeza, a proxima
+            // requisicao que cair nesta thread herda o ID da anterior. E um bug que so
+            // aparece sob carga e faz a investigacao apontar para a requisicao errada.
+            MDC.remove(RequestId.MDC_KEY);
+        }
+    }
+
+    /**
+     * Valor recebido do cliente e aceito, mas nao em qualquer formato: ele entra no log, e
+     * cabecalho e entrada do usuario. Um valor arbitrario de 8 KB polui todas as linhas.
+     */
+    private String resolve(String received) {
+        if (received == null || received.length() > 64) {
+            return UUID.randomUUID().toString();
+        }
+        String sanitized = received.replaceAll("[^A-Za-z0-9_.:-]", "");
+        // Sobrou vazio: o header veio so com caracteres que a limpeza descarta. Deixar assim
+        // poria um ID em branco no MDC, e a linha de log ficaria igual a de quem nao tem
+        // correlacao nenhuma — pior do que gerar um valor novo.
+        return sanitized.isBlank() ? UUID.randomUUID().toString() : sanitized;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,5 +54,9 @@ management:
       show-details: when-authorized
 
 logging:
+  # Injeta o correlation ID no campo de nivel do padrao default do Boot, em vez de reescrever
+  # o padrao inteiro — assim cor, timestamp e thread continuam vindo do Spring Boot.
+  pattern:
+    level: "%5p [%X{requestId:-sem-request-id}]"
   level:
     org.flywaydb: INFO

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
@@ -14,6 +14,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class AuthFlowIntegrationTest extends IntegrationTestSupport {
 
+    private String withoutInstance(String problemDetailJson) throws Exception {
+        var node = (com.fasterxml.jackson.databind.node.ObjectNode) objectMapper.readTree(problemDetailJson);
+        node.remove("instance");
+        return node.toString();
+    }
+
     @Test
     @DisplayName("Login valido devolve access token com o perfil do usuario")
     void shouldReturnTokenOnValidLogin() throws Exception {
@@ -53,7 +59,10 @@ class AuthFlowIntegrationTest extends IntegrationTestSupport {
                 .andReturn().getResponse().getContentAsString();
 
         // Se as duas respostas diferissem, daria para enumerar contas validas so pelo corpo.
-        org.junit.jupiter.api.Assertions.assertEquals(wrongPassword, unknownAccount);
+        // O instance fica de fora da comparacao: ele carrega o correlation ID da requisicao (#13),
+        // que e diferente a cada chamada por definicao e nao diz nada sobre a conta.
+        org.junit.jupiter.api.Assertions.assertEquals(
+                withoutInstance(wrongPassword), withoutInstance(unknownAccount));
     }
 
     @Test

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/CorsEnabledIntegrationTest.java
@@ -50,6 +50,18 @@ class CorsEnabledIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
+    @DisplayName("X-Request-Id e exposto para o JavaScript conseguir ler")
+    void shouldExposeRequestIdHeader() throws Exception {
+        // Header de resposta nao exposto o navegador esconde do JS: o ID chegaria na resposta
+        // e o front nao conseguiria mostra-lo em tela para o usuario reportar.
+        mockMvc.perform(options("/ideas")
+                .header("Origin", ALLOWED)
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Expose-Headers", containsString("X-Request-Id")));
+    }
+
+    @Test
     @DisplayName("Com credenciais habilitadas, Allow-Origin nunca sai como curinga")
     void shouldNeverEchoWildcardWithCredentials() throws Exception {
         // "*" com allowCredentials e recusado pelo proprio Spring em runtime; o header tem

--- a/src/test/java/br/com/fiap/aguiabranca/shared/RequestIdIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/shared/RequestIdIntegrationTest.java
@@ -1,0 +1,155 @@
+package br.com.fiap.aguiabranca.shared;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RequestIdIntegrationTest extends IntegrationTestSupport {
+
+    private ListAppender<ILoggingEvent> logs;
+    private ch.qos.logback.classic.Logger handlerLogger;
+
+    @BeforeEach
+    void captureLogs() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        handlerLogger = context.getLogger(GlobalExceptionHandler.class);
+        logs = new ListAppender<>();
+        logs.setContext(context);
+        logs.start();
+        handlerLogger.addAppender(logs);
+        handlerLogger.setLevel(Level.DEBUG);
+    }
+
+    @AfterEach
+    void releaseLogs() {
+        handlerLogger.detachAppender(logs);
+    }
+
+    @Test
+    @DisplayName("Usa o X-Request-Id recebido quando o cliente manda um")
+    void shouldReuseIncomingRequestId() throws Exception {
+        String incoming = "app-android-abc-123";
+
+        mockMvc.perform(get("/actuator/health").header(RequestId.HEADER, incoming))
+                .andExpect(status().isOk())
+                .andExpect(header().string(RequestId.HEADER, incoming));
+    }
+
+    @Test
+    @DisplayName("Gera um UUID quando o header nao vem")
+    void shouldGenerateRequestIdWhenAbsent() throws Exception {
+        String generated = mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(RequestId.HEADER))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        assertThat(generated).isNotNull().matches("[0-9a-f-]{36}");
+    }
+
+    @Test
+    @DisplayName("Header absurdamente longo e descartado em favor de um UUID")
+    void shouldRejectOversizedIncomingId() throws Exception {
+        // Cabecalho e entrada do usuario, e este valor entra em toda linha de log.
+        String abusive = "x".repeat(5000);
+
+        String applied = mockMvc.perform(get("/actuator/health").header(RequestId.HEADER, abusive))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        assertThat(applied).isNotEqualTo(abusive).matches("[0-9a-f-]{36}");
+    }
+
+    @Test
+    @DisplayName("Caracteres de controle sao removidos do ID recebido")
+    void shouldStripControlCharactersFromIncomingId() throws Exception {
+        // O ID vai para dentro da linha de log: um \n vindo do cliente forjaria uma linha
+        // inteira de log falsa, e o valor ainda voltaria no header da resposta.
+        String applied = mockMvc.perform(get("/actuator/health")
+                .header(RequestId.HEADER, "app-android\r\nFATAL linha-forjada"))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        assertThat(applied).isEqualTo("app-androidFATALlinha-forjada");
+    }
+
+    @Test
+    @DisplayName("ID que some inteiro na limpeza vira um UUID, nunca vazio")
+    void shouldFallBackWhenSanitizationEmptiesTheId() throws Exception {
+        String applied = mockMvc.perform(get("/actuator/health")
+                .header(RequestId.HEADER, "@@@ ### $$$"))
+                .andReturn().getResponse().getHeader(RequestId.HEADER);
+
+        // ID em branco no MDC sai no log identico a uma requisicao sem correlacao alguma.
+        assertThat(applied).matches("[0-9a-f-]{36}");
+    }
+
+    @Test
+    @DisplayName("O MDC fica limpo depois da requisicao")
+    void shouldClearMdcAfterRequest() throws Exception {
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+
+        // O Tomcat reusa threads: sem a limpeza, a proxima requisicao nesta thread herdaria o ID.
+        assertThat(MDC.get(RequestId.MDC_KEY)).isNull();
+    }
+
+    @Test
+    @DisplayName("O instance do ProblemDetail carrega o mesmo ID da resposta")
+    void shouldCarryRequestIdInProblemDetailInstance() throws Exception {
+        String token = tokenFor("gestor-reqid@teste.dev", Role.GESTOR);
+        String incoming = "correlacao-de-teste-1";
+
+        mockMvc.perform(patch("/projects/999/metrics")
+                .header("Authorization", bearer(token))
+                .header(RequestId.HEADER, incoming)
+                .contentType("application/json")
+                .content("{}"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(header().string(RequestId.HEADER, incoming))
+                .andExpect(jsonPath("$.instance").value("urn:request-id:" + incoming));
+    }
+
+    @Test
+    @DisplayName("Resposta 401 tambem sai correlacionada, mesmo vindo de fora do MVC")
+    void shouldCorrelateUnauthenticatedResponses() throws Exception {
+        String incoming = "correlacao-sem-token";
+
+        // O 401 e escrito pelo entry point do Spring Security, fora do @RestControllerAdvice:
+        // se o filtro de ID nao envolvesse a cadeia de seguranca, esta resposta sairia sem ID.
+        mockMvc.perform(get("/ideas").header(RequestId.HEADER, incoming))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.instance").value("urn:request-id:" + incoming));
+    }
+
+    @Test
+    @DisplayName("As linhas de log do GlobalExceptionHandler saem com o ID no MDC")
+    void shouldCorrelateHandlerLogLines() throws Exception {
+        String token = tokenFor("gestor-log@teste.dev", Role.GESTOR);
+        String incoming = "correlacao-de-log-9";
+
+        mockMvc.perform(patch("/projects/999/metrics")
+                .header("Authorization", bearer(token))
+                .header(RequestId.HEADER, incoming)
+                .contentType("application/json")
+                .content("{}"))
+                .andExpect(status().isUnprocessableEntity());
+
+        assertThat(logs.list)
+                .isNotEmpty()
+                .allSatisfy(event -> assertThat(event.getMDCPropertyMap())
+                        .containsEntry(RequestId.MDC_KEY, incoming));
+    }
+}


### PR DESCRIPTION
## O que muda

Toda linha de log de uma requisição passa a sair com o mesmo identificador, e esse identificador
volta para o cliente. Investigar um erro relatado pelo app deixa de ser caçar linha por horário.

- `RequestIdFilter` lê `X-Request-Id`, ou gera um UUID, e põe o valor no MDC
- O ID volta na resposta no header `X-Request-Id`
- `logging.pattern.level` imprime o ID em toda linha: `INFO [app-android-7f3a]`
- O `instance` do ProblemDetail vira `urn:request-id:<id>` em vez do path
- CORS passa a **expor** o header, para o front web da #10 conseguir lê-lo

Closes #13

### Três escolhas que valem explicar

**Ordem máxima no filtro, não "antes do JWT".** `HIGHEST_PRECEDENCE` põe o filtro na frente da
cadeia inteira do Spring Security, não só do `JwtAuthenticationFilter`. Sem isso, o 401 — que é
justamente o que mais se investiga — sairia sem correlação, porque quem o escreve é o
`AuthenticationEntryPoint`, fora do `@RestControllerAdvice`. O teste
`shouldCorrelateUnauthenticatedResponses` falha se alguém baixar essa ordem.

**`instance` aponta para a ocorrência, não para o recurso.** O path já está no `type` e na URL
que o cliente chamou; repeti-lo no `instance` não acrescenta nada. Com o ID ali, um print de tela
do erro basta para achar as linhas daquela requisição exata. A RFC 7807 permite os dois — o campo
identifica "a ocorrência específica do problema".

**O valor recebido é limpo antes de entrar no log.** Header é entrada de usuário e vai parar
dentro da linha de log: um `\r\n` vindo do cliente forjaria uma linha inteira de log falsa. Acima
de 64 caracteres, ou sobrando vazio depois da limpeza, a API descarta e gera o próprio UUID.

## Como validar

```
./mvnw -B clean verify
```

`Tests run: 43, Failures: 0, Errors: 0, Skipped: 0`

| Teste | Critério de aceite que cobre |
|---|---|
| `shouldReuseIncomingRequestId` | usa o `X-Request-Id` recebido |
| `shouldGenerateRequestIdWhenAbsent` | gera UUID quando ausente |
| `shouldCorrelateHandlerLogLines` | ID em toda linha, inclusive do `GlobalExceptionHandler` |
| `shouldClearMdcAfterRequest` | MDC limpo ao fim, sem vazar entre requisições |
| `shouldCarryRequestIdInProblemDetailInstance` | `instance` carrega o mesmo ID |
| `shouldCorrelateUnauthenticatedResponses` | 401 escrito fora do MVC também sai correlacionado |
| `shouldRejectOversizedIncomingId` / `shouldStripControlCharactersFromIncomingId` / `shouldFallBackWhenSanitizationEmptiesTheId` | limpeza do valor do cliente |
| `shouldExposeRequestIdHeader` | navegador consegue ler o header de volta |

Olhando o log do build dá para ver o padrão funcionando já no boot:

```
2026-08-27T13:52:52.566-03:00  INFO [sem-request-id] --- o.f.core.internal.command.DbValidate : Successfully validated 1 migration
```

O `sem-request-id` é o default do `%X{requestId:-sem-request-id}`: linha de fora do ciclo de
requisição não tem ID, e mostrar isso explicitamente é melhor do que um colchete vazio.

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer — n/a, sem migration
- [x] Mudança de contrato de API está refletida no `README.md` — nova seção "Correlation ID"
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta — não quebra (o header é opcional), mas a #38 existe para o app mandar o ID e o log virar útil de ponta a ponta

## Risco

Duas mudanças de comportamento visíveis, ambas de baixo impacto no cliente atual:

**O `instance` do ProblemDetail mudou de conteúdo.** Quem estivesse lendo o path dali passa a ler
uma URN. O app Android não lê esse campo hoje, e o README já dizia que o campo estável para
decidir comportamento é o `type`, nunca outro.

**Um filtro novo na frente de tudo.** Ele só escreve no MDC e num header; não lê corpo, não
consome stream, não decide autorização. O custo por requisição é um `UUID.randomUUID()` quando o
cliente não manda o header.

Rollback é reverter o commit: nada persiste em banco e nenhuma migration é aplicada.

---

Base do PR é `chore/ci-workflow` (#39), que carrega o stack da aplicação. Depois do merge de #39
o GitHub retargeta este PR para a `main` sozinho.
