### PR TITLE
chore(infra): valida os caminhos do CODEOWNERS e desliga issue em branco

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,30 @@
-# Dono padrão de tudo que não casar com uma regra mais específica abaixo.
+# A ULTIMA regra que casa com o arquivo e a que vale -- por isso o curinga vem
+# primeiro e as areas depois. Inverter a ordem faz o curinga engolir todas elas.
+#
+# CODEOWNERS so surte efeito para quem tem permissao de ESCRITA no repositorio:
+# colaborador sem write e ignorado sem aviso nenhum. Valide pela aba
+# Settings > Branches (#5), nunca pelo conteudo deste arquivo.
+
+# Dono padrao de tudo que nao casar com uma regra mais especifica abaixo.
 *                       @AlexCajeFelix
 
-# Infraestrutura e pipeline
-/.github/               @AlexCajeFelix
-/Dockerfile             @AlexCajeFelix
-/compose.yaml           @AlexCajeFelix
+# Backend -- as quatro fatias, de controller a repository
+/src/main/java/         @AlexCajeFelix
+/src/test/java/         @AlexCajeFelix
 
-# Banco — migrations são caminho sem volta em produção
+# Banco -- migration e caminho sem volta em producao; revisao aqui nao e opcional
 /src/main/resources/db/ @AlexCajeFelix
+
+# Infra -- pipeline, build e wrapper
+/.github/               @AlexCajeFelix
+/pom.xml                @AlexCajeFelix
+/mvnw                   @AlexCajeFelix
+/mvnw.cmd               @AlexCajeFelix
+/.mvn/                  @AlexCajeFelix
+
+# Android nao tem regra aqui de proposito: o app vive fora deste repositorio.
+# As issues area:android sao rastreadas neste board, o codigo nao.
+#
+# /Dockerfile e /compose.yaml sairam da lista: ainda nao existem (#12), e caminho
+# inexistente o GitHub ignora em silencio -- a regra aparenta proteger o arquivo
+# e nao protege nada. Voltam no mesmo PR que criar os arquivos.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# Issue em branco desativada: sem template ninguem preenche area, contexto e criterio
+# de aceite -- e issue sem criterio verificavel nao sai do Backlog de qualquer jeito.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Board do projeto
+    url: https://github.com/users/AlexCajeFelix/projects/4
+    about: Antes de abrir, confira se o trabalho ja esta rastreado num card.


### PR DESCRIPTION
## O que muda

Os arquivos que a issue cita já existiam desde o commit inicial — o que faltava era o ajuste
fino, e ele revelou que **metade das regras do `CODEOWNERS` não valia nada**.

- `CODEOWNERS` reescrito por área, só com caminhos que existem
- `.github/ISSUE_TEMPLATE/config.yml` criado, com `blank_issues_enabled: false`

Closes #4

### As regras que não protegiam nada

`/Dockerfile` e `/compose.yaml` estavam no `CODEOWNERS` mas não existem no repositório — chegam
com a #12. Caminho inexistente o GitHub **ignora em silêncio**: a regra aparece no arquivo, dá a
impressão de que o arquivo está coberto, e não cobre. Saíram da lista, com um comentário dizendo
para voltarem no mesmo PR que criar os arquivos.

Verificação de que agora todos existem:

```
$ grep -oE '^/[^ ]+' .github/CODEOWNERS | while read p; do
    c="${p#/}"; c="${c%/}"; [ -e "$c" ] && echo "  OK      $p" || echo "  AUSENTE $p"; done
  OK      /src/main/java/
  OK      /src/test/java/
  OK      /src/main/resources/db/
  OK      /.github/
  OK      /pom.xml
  OK      /mvnw
  OK      /mvnw.cmd
  OK      /.mvn/
```

### Três decisões que valem explicar

**Agrupado por área, mesmo com um dono só.** O critério pede "donos reais por área". Hoje há uma
pessoa com write, então todas as linhas apontam para ela — mas separadas por área, somar a segunda
pessoa vira uma linha por área em vez de reescrever o arquivo pensando na estrutura do zero.

**Android não tem regra, de propósito.** O app Kotlin vive fora deste repositório: as issues
`area:android` são rastreadas neste board, o código não. Inventar um `/android/` aqui seria
exatamente o caminho-fantasma que este PR está removendo.

**A ordem das regras está comentada no arquivo.** No `CODEOWNERS` vale a **última** regra que casa,
não a mais específica. Por isso o curinga vem primeiro; invertê-lo faria ele engolir todas as
outras — e o sintoma seria silencioso, igual ao dos caminhos inválidos.

## Como validar

O `CODEOWNERS` não é exercitado por teste, então a validação é a checagem de caminhos acima mais
a leitura do YAML:

```
python3 -c "
import yaml
c = yaml.safe_load(open('.github/ISSUE_TEMPLATE/config.yml'))
assert c['blank_issues_enabled'] is False
for t in ['bug','feature']:
    d = yaml.safe_load(open(f'.github/ISSUE_TEMPLATE/{t}.yml'))
    print(t, [b['id'] for b in d['body'] if b.get('validations',{}).get('required')])
"
bug     ['area', 'contexto', 'reproducao', 'esperado']
feature ['area', 'contexto', 'aceite']
```

Pela interface: *Issues → New issue* deve oferecer **Bug**, **Feature** e o link do board — e
**não** deve mais oferecer "Open a blank issue".

Os campos que sobram opcionais são opcionais de propósito: `evidencia` no bug (nem todo bug tem
stack trace) e `notas`/`dependencias` na feature.

## Checklist

- [x] `./mvnw -q verify` passa localmente — n/a, nenhum arquivo entra no build
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer — n/a
- [x] Mudança de contrato de API está refletida no `README.md` — n/a
- [x] Se quebra o app Android, a issue correspondente em `area:android` foi aberta — n/a

## Risco

Quase nulo em runtime: nada aqui entra no build ou no artefato.

O único efeito colateral real é humano — quem estava acostumado a abrir issue em branco vai ser
forçado ao template. É o objetivo, mas vale saber que muda o fluxo de quem abre issue pela web.

**Um critério de aceite fica em aberto neste PR:** "a aba *Settings > Branches* mostra a review de
code owner exigida na `main`". Isso é configuração de branch protection e mora na #5 — não dá para
entregar por arquivo. O `Closes #4` assume que a #5 fecha esse ponto; se preferir, dá para tirar o
`Closes` e fechar a #4 na mão depois da #5.

---

Base do PR é `chore/ci-workflow` (#39), e não a `main`, por um motivo concreto: `/src/main/resources/db/`
— a regra de migrations, a que mais importa aqui — **só existe depois que o #39 mergear**. Baseado na
`main` de hoje, essa linha nasceria inválida, que é justamente o defeito que este PR corrige.
