### PR TITLE
feat(auth): refresh token rotacionado

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,19 @@ curl -s localhost:8080/auth/login -H 'Content-Type: application/json' \
   -d '{"email":"gestor@aguiabranca.dev","password":"gestor123"}'
 ```
 
+O login devolve `accessToken` (30 min) e `refreshToken` (7 dias, opaco, revogável). Quando o
+access expirar, `POST /auth/refresh` com o refresh atual troca o par. Cada refresh invalida o
+token usado; reusar um já rotacionado revoga a família inteira daquele login (sessão
+comprometida) e responde `type` `https://aguiabranca.fiap.br/errors/refresh-invalido`.
+`POST /auth/logout` invalida o refresh corrente.
+
 ## Rotas
 
 | Método | Rota | Quem pode |
 |---|---|---|
 | `POST` | `/auth/login` | público |
+| `POST` | `/auth/refresh` | público (body com refresh token) |
+| `POST` | `/auth/logout` | público (body com refresh token) |
 | `POST` | `/ideas` | qualquer autenticado |
 | `GET` | `/ideas?status=` | autenticado — `OPERADOR` só vê as próprias |
 | `GET` | `/ideas/{id}` | autenticado — ideia alheia responde 404 para `OPERADOR` |
@@ -116,7 +124,7 @@ vazio depois da limpeza, a API descarta e gera o próprio.
 | Runtime | Java 21 |
 | Framework | Spring Boot 3.3.5 |
 | Banco | PostgreSQL + Flyway |
-| Auth | JWT HS256 (jjwt 0.12) |
+| Auth | JWT HS256 (jjwt 0.12) + refresh opaco rotacionado |
 | Erros | RFC 7807 (`ProblemDetail`) |
 | Testes | JUnit 5 + Testcontainers |
 | App cliente | Android (Kotlin) |

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthController.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthController.java
@@ -22,4 +22,15 @@ public class AuthController {
     public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+        return ResponseEntity.ok(authService.refresh(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@Valid @RequestBody RefreshRequest request) {
+        authService.logout(request);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthService.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthService.java
@@ -2,6 +2,8 @@ package br.com.fiap.aguiabranca.domain.auth;
 
 import br.com.fiap.aguiabranca.domain.user.User;
 import br.com.fiap.aguiabranca.domain.user.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -13,14 +15,19 @@ public class AuthService {
     private final UserRepository users;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final RefreshTokenRepository refreshTokens;
+    private final JwtProperties jwtProperties;
 
-    public AuthService(UserRepository users, PasswordEncoder passwordEncoder, JwtService jwtService) {
+    public AuthService(UserRepository users, PasswordEncoder passwordEncoder, JwtService jwtService,
+            RefreshTokenRepository refreshTokens, JwtProperties jwtProperties) {
         this.users = users;
         this.passwordEncoder = passwordEncoder;
         this.jwtService = jwtService;
+        this.refreshTokens = refreshTokens;
+        this.jwtProperties = jwtProperties;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public TokenResponse login(LoginRequest request) {
         User user = users.findByEmail(request.email())
                 .orElseThrow(() -> new BadCredentialsException("credenciais invalidas"));
@@ -29,6 +36,54 @@ public class AuthService {
             throw new BadCredentialsException("credenciais invalidas");
         }
 
-        return new TokenResponse(jwtService.generate(user), jwtService.expiresInSeconds(), user.getRole());
+        return issuePair(user, UUID.randomUUID());
+    }
+
+    /**
+     * Troca um refresh valido por um par novo e invalida o usado.
+     * Reuso de um token ja rotacionado revoga a familia inteira — sinal de roubo.
+     *
+     * InvalidRefreshTokenException nao reverte a transacao: a revogacao da familia
+     * precisa persistir, senao o token recem-rotacionado continua valido.
+     */
+    @Transactional(noRollbackFor = InvalidRefreshTokenException.class)
+    public TokenResponse refresh(RefreshRequest request) {
+        RefreshToken current = lookup(request.refreshToken());
+        Instant now = Instant.now();
+
+        if (current.isRevoked()) {
+            refreshTokens.findByFamilyId(current.getFamilyId())
+                    .forEach(token -> token.revoke(now));
+            throw new InvalidRefreshTokenException();
+        }
+
+        if (current.isExpired(now)) {
+            current.revoke(now);
+            throw new InvalidRefreshTokenException();
+        }
+
+        current.revoke(now);
+        User user = current.getUser();
+        UUID familyId = current.getFamilyId();
+        return issuePair(user, familyId);
+    }
+
+    @Transactional(noRollbackFor = InvalidRefreshTokenException.class)
+    public void logout(RefreshRequest request) {
+        RefreshToken current = lookup(request.refreshToken());
+        current.revoke(Instant.now());
+    }
+
+    private RefreshToken lookup(String raw) {
+        return refreshTokens.findByTokenHashForUpdate(RefreshTokens.hash(raw))
+                .orElseThrow(InvalidRefreshTokenException::new);
+    }
+
+    private TokenResponse issuePair(User user, UUID familyId) {
+        String rawRefresh = RefreshTokens.generateRaw();
+        Instant expiresAt = Instant.now().plus(jwtProperties.refreshExpiration());
+        refreshTokens.save(new RefreshToken(RefreshTokens.hash(rawRefresh), user, familyId, expiresAt));
+        return new TokenResponse(jwtService.generate(user), rawRefresh, jwtService.expiresInSeconds(),
+                user.getRole());
     }
 }

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/InvalidRefreshTokenException.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/InvalidRefreshTokenException.java
@@ -1,0 +1,14 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+/**
+ * Refresh inexistente, expirado, ja usado ou de familia revogada.
+ *
+ * Tipo proprio no ProblemDetail: o app diferencia "sessao expirada, peca login"
+ * de "credenciais de login erradas" sem olhar o title.
+ */
+public class InvalidRefreshTokenException extends RuntimeException {
+
+    public InvalidRefreshTokenException() {
+        super("Refresh token invalido ou expirado.");
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/JwtProperties.java
@@ -4,11 +4,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * TODO(#8): expiration de 8h sem refresh — o app expulsa o usuario no meio do uso.
- */
 @ConfigurationProperties(prefix = "app.jwt")
-public record JwtProperties(String secret, Duration expiration) {
+public record JwtProperties(String secret, Duration expiration, Duration refreshExpiration) {
 
     /** HS256 assina com bloco de 256 bits: chave menor enfraquece a assinatura. */
     static final int MIN_SECRET_BYTES = 32;

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshRequest.java
@@ -1,0 +1,7 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank(message = "Refresh token e obrigatorio") String refreshToken) {
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshToken.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshToken.java
@@ -1,0 +1,91 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "family_id", nullable = false)
+    private UUID familyId;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    protected RefreshToken() {
+    }
+
+    public RefreshToken(String tokenHash, User user, UUID familyId, Instant expiresAt) {
+        this.tokenHash = tokenHash;
+        this.user = user;
+        this.familyId = familyId;
+        this.expiresAt = expiresAt;
+        this.createdAt = Instant.now();
+    }
+
+    public void revoke(Instant when) {
+        if (this.revokedAt == null) {
+            this.revokedAt = when;
+        }
+    }
+
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
+    public boolean isExpired(Instant now) {
+        return !expiresAt.isAfter(now);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public UUID getFamilyId() {
+        return familyId;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public Instant getRevokedAt() {
+        return revokedAt;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshTokenRepository.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import jakarta.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM RefreshToken t WHERE t.tokenHash = :hash")
+    Optional<RefreshToken> findByTokenHashForUpdate(@Param("hash") String hash);
+
+    List<RefreshToken> findByFamilyId(UUID familyId);
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshTokens.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/RefreshTokens.java
@@ -1,0 +1,37 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/**
+ * Refresh token opaco. Nao e JWT: sem contraparte no banco nao ha como revogar.
+ * O valor em claro so viaja na resposta; o banco guarda o SHA-256.
+ */
+final class RefreshTokens {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int RAW_BYTES = 32;
+
+    private RefreshTokens() {
+    }
+
+    static String generateRaw() {
+        byte[] bytes = new byte[RAW_BYTES];
+        RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    static String hash(String raw) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(raw.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 e obrigatorio na JVM", ex);
+        }
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login").permitAll()
+                        .requestMatchers("/auth/login", "/auth/refresh", "/auth/logout").permitAll()
                         // Publica para o healthcheck do compose (#12) conseguir bater sem token.
                         .requestMatchers("/actuator/health").permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/TokenResponse.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/TokenResponse.java
@@ -2,5 +2,5 @@ package br.com.fiap.aguiabranca.domain.auth;
 
 import br.com.fiap.aguiabranca.domain.user.Role;
 
-public record TokenResponse(String accessToken, long expiresIn, Role role) {
+public record TokenResponse(String accessToken, String refreshToken, long expiresIn, Role role) {
 }

--- a/src/main/java/br/com/fiap/aguiabranca/shared/ErrorTypes.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/ErrorTypes.java
@@ -22,6 +22,7 @@ public final class ErrorTypes {
     public static final String PROJECT_NO_METRIC = BASE + "nenhuma-metrica-informada";
     public static final String STRATEGY_NOT_FOUND = BASE + "estrategia-nao-encontrada";
     public static final String INVALID_CREDENTIALS = BASE + "credenciais-invalidas";
+    public static final String INVALID_REFRESH = BASE + "refresh-invalido";
     public static final String UNAUTHENTICATED = BASE + "nao-autenticado";
     public static final String FORBIDDEN = BASE + "sem-permissao";
 

--- a/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package br.com.fiap.aguiabranca.shared;
 
+import br.com.fiap.aguiabranca.domain.auth.InvalidRefreshTokenException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import org.slf4j.Logger;
@@ -54,6 +55,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         // as duas entrega ao atacante uma lista de contas validas.
         return problem(HttpStatus.UNAUTHORIZED, "Credenciais invalidas", ErrorTypes.INVALID_CREDENTIALS,
                 "E-mail ou senha incorretos.", request);
+    }
+
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    public ProblemDetail handleInvalidRefresh(InvalidRefreshTokenException ex, HttpServletRequest request) {
+        return problem(HttpStatus.UNAUTHORIZED, "Refresh token invalido", ErrorTypes.INVALID_REFRESH,
+                ex.getMessage(), request);
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,8 +36,8 @@ app:
     # Sem default: a aplicacao nao sobe sem JWT_SECRET no ambiente. Para desenvolvimento,
     # o valor vem do profile dev (application-dev.yml), nunca daqui.
     secret: ${JWT_SECRET:}
-    # TODO(#8): 8h sem renovacao — o app derruba o usuario no meio do uso quando expira.
-    expiration: PT8H
+    expiration: PT30M
+    refresh-expiration: P7D
 
 management:
   endpoints:

--- a/src/main/resources/db/migration/V3__refresh_tokens.sql
+++ b/src/main/resources/db/migration/V3__refresh_tokens.sql
@@ -1,0 +1,16 @@
+-- Refresh token revogavel. O valor em claro nunca entra no banco: so o SHA-256.
+-- family_id amarra a cadeia de rotacao de um login; reuso de um token ja
+-- rotacionado revoga a familia inteira (sessao comprometida).
+
+CREATE TABLE refresh_tokens (
+    id         BIGSERIAL PRIMARY KEY,
+    token_hash VARCHAR(64)  NOT NULL UNIQUE,
+    user_id    BIGINT       NOT NULL REFERENCES users (id),
+    family_id  UUID         NOT NULL,
+    expires_at TIMESTAMPTZ  NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_refresh_tokens_family ON refresh_tokens (family_id);
+CREATE INDEX idx_refresh_tokens_user ON refresh_tokens (user_id);

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthFlowIntegrationTest.java
@@ -32,8 +32,9 @@ class AuthFlowIntegrationTest extends IntegrationTestSupport {
                         """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty())
                 .andExpect(jsonPath("$.role").value("GESTOR"))
-                .andExpect(jsonPath("$.expiresIn").isNumber());
+                .andExpect(jsonPath("$.expiresIn").value(1800));
     }
 
     @Test

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretValidationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/JwtSecretValidationTest.java
@@ -20,7 +20,7 @@ class JwtSecretValidationTest {
     private final ApplicationContextRunner runner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of())
             .withUserConfiguration(JwtTestConfiguration.class)
-            .withPropertyValues("app.jwt.expiration=PT8H");
+            .withPropertyValues("app.jwt.expiration=PT30M", "app.jwt.refresh-expiration=P7D");
 
     @Test
     @DisplayName("Sobe com segredo proprio de 32 bytes ou mais")

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/RefreshTokenIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/RefreshTokenIntegrationTest.java
@@ -1,0 +1,123 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RefreshTokenIntegrationTest extends IntegrationTestSupport {
+
+    private static final String REFRESH_TYPE = "https://aguiabranca.fiap.br/errors/refresh-invalido";
+
+    @Test
+    @DisplayName("Refresh feliz troca o par e o access novo acessa rota protegida")
+    void shouldRotateRefreshAndIssueNewAccess() throws Exception {
+        Tokens original = loginTokens("gestor@teste.dev", Role.GESTOR);
+
+        String body = mockMvc.perform(post("/auth/refresh")
+                .contentType("application/json")
+                .content(refreshBody(original.refreshToken())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty())
+                .andExpect(jsonPath("$.role").value("GESTOR"))
+                .andExpect(jsonPath("$.expiresIn").value(1800))
+                .andReturn().getResponse().getContentAsString();
+
+        Tokens rotated = tokensFrom(body);
+        assertThat(rotated.refreshToken()).isNotEqualTo(original.refreshToken());
+
+        mockMvc.perform(get("/ideas").header("Authorization", bearer(rotated.accessToken())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Reuso de refresh ja rotacionado responde 401 e revoga a familia")
+    void shouldRevokeFamilyOnRefreshReuse() throws Exception {
+        Tokens original = loginTokens("reuso@teste.dev", Role.OPERADOR);
+
+        String firstRefresh = mockMvc.perform(post("/auth/refresh")
+                .contentType("application/json")
+                .content(refreshBody(original.refreshToken())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        Tokens rotated = tokensFrom(firstRefresh);
+
+        mockMvc.perform(post("/auth/refresh")
+                .contentType("application/json")
+                .content(refreshBody(original.refreshToken())))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.type").value(REFRESH_TYPE))
+                .andExpect(jsonPath("$.status").value(401));
+
+        mockMvc.perform(post("/auth/refresh")
+                .contentType("application/json")
+                .content(refreshBody(rotated.refreshToken())))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.type").value(REFRESH_TYPE));
+    }
+
+    @Test
+    @DisplayName("Logout invalida o refresh corrente")
+    void shouldInvalidateRefreshOnLogout() throws Exception {
+        Tokens tokens = loginTokens("sair@teste.dev", Role.GESTOR);
+
+        mockMvc.perform(post("/auth/logout")
+                .contentType("application/json")
+                .content(refreshBody(tokens.refreshToken())))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/auth/refresh")
+                .contentType("application/json")
+                .content(refreshBody(tokens.refreshToken())))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.type").value(REFRESH_TYPE));
+    }
+
+    @Test
+    @DisplayName("Refresh expirado responde 401 com type proprio")
+    void shouldRejectExpiredRefresh() throws Exception {
+        Tokens tokens = loginTokens("expirado@teste.dev", Role.LIDERANCA);
+
+        jdbcTemplate.update("UPDATE refresh_tokens SET expires_at = now() - interval '1 second'");
+
+        mockMvc.perform(post("/auth/refresh")
+                .contentType("application/json")
+                .content(refreshBody(tokens.refreshToken())))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.type").value(REFRESH_TYPE))
+                .andExpect(jsonPath("$.title").value("Refresh token invalido"));
+    }
+
+    private Tokens loginTokens(String email, Role role) throws Exception {
+        givenUser(email, "senha-forte-123", role);
+        String response = mockMvc.perform(post("/auth/login")
+                .contentType("application/json")
+                .content("""
+                        {"email": "%s", "password": "senha-forte-123"}
+                        """.formatted(email)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return tokensFrom(response);
+    }
+
+    private Tokens tokensFrom(String json) throws Exception {
+        var node = objectMapper.readTree(json);
+        return new Tokens(node.path("accessToken").asText(), node.path("refreshToken").asText());
+    }
+
+    private static String refreshBody(String refreshToken) throws Exception {
+        return """
+                {"refreshToken": "%s"}
+                """.formatted(refreshToken);
+    }
+
+    private record Tokens(String accessToken, String refreshToken) {
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
+++ b/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
@@ -68,7 +68,7 @@ public abstract class IntegrationTestSupport {
     @BeforeEach
     void resetDatabase() {
         jdbcTemplate.execute("""
-                TRUNCATE TABLE project_metrics_history, projects, ideas, strategies, users
+                TRUNCATE TABLE refresh_tokens, project_metrics_history, projects, ideas, strategies, users
                 RESTART IDENTITY CASCADE
                 """);
     }


### PR DESCRIPTION
## O que muda

Access token passa a durar 30 minutos. Login e refresh devolvem um refresh token opaco (hash no banco, `family_id` por sessão). Rotação a cada uso; reuso revoga a família inteira; logout invalida o corrente.

Closes #8

## Como validar

```
./mvnw -q verify
```

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer
- [x] Mudança de contrato de API está refletida no `README.md` / `api.http`
- [ ] Se quebra o app Android, a issue correspondente em `area:android` foi aberta

## Risco

App que ainda espera access de 8h sem `refreshToken` no JSON vai precisar renovar mais cedo. Rollback: reverter o PR e não aplicar a V3 em produção se ainda não rodou.

Made with [Cursor](https://cursor.com)