### PR TITLE
chore(banco): plano de execucao das queries do dashboard

### DIFF
--- a/docs/dashboard-query-plan.md
+++ b/docs/dashboard-query-plan.md
@@ -1,0 +1,45 @@
+# Plano das queries do dashboard (#14)
+
+Massa: `src/test/resources/db/dashboard-load-100k.sql` (100_000 projetos, status
+uniforme, sem `idea_id`). Rodado em PostgreSQL 16 via Testcontainers depois de
+`ANALYZE projects`.
+
+## Decisão
+
+**Os índices da V1 bastam.** Não há migration nova.
+
+As duas queries agregam a tabela inteira, sem `WHERE`. Seq Scan nesse caso é o
+plano correto — índice não evita ler `progress`/`budget` de todas as linhas.
+`idx_projects_status` só ajudaria se houvesse filtro por status. Tempo medido
+fica bem abaixo dos 200 ms (≈18 ms e ≈21 ms). Tabela de resumo ou cache só
+fariam sentido com volume ordens de grandeza maior.
+
+O teste `DashboardQueryPlanTest` reexecuta a medição no CI.
+
+## `summarize()` — `COUNT` / `AVG(progress)` / `SUM(budget)`
+
+```
+Aggregate  (cost=2886.01..2886.02 rows=1 width=72) (actual time=17.640..17.641 rows=1 loops=1)
+  Buffers: shared hit=1136
+  ->  Seq Scan on projects  (cost=0.00..2136.00 rows=100000 width=10) (actual time=0.005..6.026 rows=100000 loops=1)
+        Buffers: shared hit=1136
+Planning Time: 0.445 ms
+Execution Time: 17.660 ms
+```
+
+## `countByStatusGrouped()` — `GROUP BY status`
+
+```
+Sort  (cost=2636.08..2636.09 rows=4 width=18) (actual time=21.252..21.253 rows=4 loops=1)
+  Sort Key: status
+  Sort Method: quicksort  Memory: 25kB
+  Buffers: shared hit=1136
+  ->  HashAggregate  (cost=2636.00..2636.04 rows=4 width=18) (actual time=21.232..21.234 rows=4 loops=1)
+        Group Key: status
+        Batches: 1  Memory Usage: 24kB
+        Buffers: shared hit=1136
+        ->  Seq Scan on projects  (cost=0.00..2136.00 rows=100000 width=10) (actual time=0.008..6.052 rows=100000 loops=1)
+              Buffers: shared hit=1136
+Planning Time: 0.115 ms
+Execution Time: 21.314 ms
+```

--- a/src/test/java/br/com/fiap/aguiabranca/domain/project/DashboardQueryPlanTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/project/DashboardQueryPlanTest.java
@@ -1,0 +1,82 @@
+package br.com.fiap.aguiabranca.domain.project;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mede o plano das agregacoes do dashboard com 100k projetos (#14).
+ *
+ * As duas queries varrem a tabela inteira — nao ha filtro aplicavel. Seq Scan
+ * nesse cenario e o plano honesto; o indice idx_projects_status da V1 cobre o
+ * GROUP BY de status, mas nao evita a leitura das colunas de budget/progress.
+ */
+class DashboardQueryPlanTest extends IntegrationTestSupport {
+
+    private static final double MAX_MS = 200.0;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Test
+    @DisplayName("summarize e countByStatusGrouped rodam abaixo de 200ms com 100k projetos")
+    void dashboardQueriesShouldStayUnderBudgetWithRealisticVolume() {
+        new ResourceDatabasePopulator(new ClassPathResource("db/dashboard-load-100k.sql"))
+                .execute(jdbcTemplate.getDataSource());
+
+        Long loaded = jdbcTemplate.queryForObject("SELECT count(*) FROM projects", Long.class);
+        assertThat(loaded).isEqualTo(100_000L);
+
+        jdbcTemplate.execute("ANALYZE projects");
+
+        String summarizePlan = explain("""
+                SELECT count(*), avg(progress), sum(budget) FROM projects
+                """);
+        String groupedPlan = explain("""
+                SELECT status, count(*) FROM projects GROUP BY status ORDER BY status
+                """);
+
+        System.out.println("=== EXPLAIN summarize() ===");
+        System.out.println(summarizePlan);
+        System.out.println("=== EXPLAIN countByStatusGrouped() ===");
+        System.out.println(groupedPlan);
+
+        assertThat(executionMs(summarizePlan)).isLessThan(MAX_MS);
+        assertThat(executionMs(groupedPlan)).isLessThan(MAX_MS);
+
+        long summarizeStart = System.nanoTime();
+        ProjectSummaryDto summary = projectRepository.summarize();
+        double summarizeJavaMs = (System.nanoTime() - summarizeStart) / 1_000_000.0;
+
+        long groupedStart = System.nanoTime();
+        List<ProjectStatusCount> grouped = projectRepository.countByStatusGrouped();
+        double groupedJavaMs = (System.nanoTime() - groupedStart) / 1_000_000.0;
+
+        assertThat(summary.totalProjects()).isEqualTo(100_000L);
+        assertThat(grouped).hasSize(ProjectStatus.values().length);
+        assertThat(summarizeJavaMs).isLessThan(MAX_MS);
+        assertThat(groupedJavaMs).isLessThan(MAX_MS);
+    }
+
+    private String explain(String sql) {
+        List<String> lines = jdbcTemplate.query(
+                "EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) " + sql,
+                (rs, rowNum) -> rs.getString(1));
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    private static double executionMs(String plan) {
+        return plan.lines()
+                .filter(line -> line.contains("Execution Time:"))
+                .map(line -> line.replace("Execution Time:", "").replace("ms", "").trim())
+                .mapToDouble(value -> Double.parseDouble(value.replace(',', '.')))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("EXPLAIN sem Execution Time:\n" + plan));
+    }
+}

--- a/src/test/resources/db/dashboard-load-100k.sql
+++ b/src/test/resources/db/dashboard-load-100k.sql
@@ -1,0 +1,12 @@
+-- Massa realista para medir summarize() e countByStatusGrouped() (#14).
+-- idea_id fica NULL de proposito: o dashboard agrega a tabela inteira, nao o join com ideas.
+
+INSERT INTO projects (name, status, progress, budget, spent, created_at)
+SELECT
+    'Projeto carga ' || g,
+    (ARRAY['PLANNING', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED'])[1 + (g % 4)],
+    g % 101,
+    ((g % 500) * 1000)::numeric(15, 2),
+    0,
+    now()
+FROM generate_series(1, 100000) AS g;


### PR DESCRIPTION
## O que muda

Massa de 100k projetos, `EXPLAIN (ANALYZE, BUFFERS)` das duas agregacoes do dashboard e um teste que barra regressao acima de 200 ms.

Closes #14

## Como validar

```
./mvnw -q -Dtest=DashboardQueryPlanTest test
```

## Decisão

**Os índices da V1 bastam.** Não há migration nova.

As duas queries agregam a tabela inteira, sem `WHERE`. Seq Scan nesse caso é o plano correto — índice não evita ler `progress`/`budget` de todas as linhas. `idx_projects_status` só ajudaria com filtro por status.

Capturado em PostgreSQL 16 (Testcontainers), depois de `ANALYZE projects`:

### summarize()

```
Aggregate  (cost=2886.01..2886.02 rows=1 width=72) (actual time=17.640..17.641 rows=1 loops=1)
  Buffers: shared hit=1136
  ->  Seq Scan on projects  (cost=0.00..2136.00 rows=100000 width=10) (actual time=0.005..6.026 rows=100000 loops=1)
        Buffers: shared hit=1136
Planning Time: 0.445 ms
Execution Time: 17.660 ms
```

### countByStatusGrouped()

```
Sort  (cost=2636.08..2636.09 rows=4 width=18) (actual time=21.252..21.253 rows=4 loops=1)
  Sort Key: status
  Sort Method: quicksort  Memory: 25kB
  Buffers: shared hit=1136
  ->  HashAggregate  (cost=2636.00..2636.04 rows=4 width=18) (actual time=21.232..21.234 rows=4 loops=1)
        Group Key: status
        Batches: 1  Memory Usage: 24kB
        Buffers: shared hit=1136
        ->  Seq Scan on projects  (cost=0.00..2136.00 rows=100000 width=10) (actual time=0.008..6.052 rows=100000 loops=1)
              Buffers: shared hit=1136
Planning Time: 0.115 ms
Execution Time: 21.314 ms
```

Detalhe em `docs/dashboard-query-plan.md`.

## Checklist

- [x] `./mvnw -q verify` — o teste de plano passa; verify completo na CI
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer (não há migration)
- [ ] Mudança de contrato de API está refletida no `README.md` / `api.http`
- [ ] Se quebra o app Android, a issue correspondente em `area:android` foi aberta

## Risco

Nenhum em produção: só teste e documentação. Se o volume crescer ordens de grandeza, aí sim tabela de resumo ou cache.

Made with [Cursor](https://cursor.com)