### PR TITLE
chore(ci): publica o contrato OpenAPI como artefato

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Build e testes
         run: ./mvnw -B verify
 
+      - name: Publica contrato OpenAPI
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi
+          path: target/openapi.json
+          retention-days: 30
+          if-no-files-found: error
+
       - name: Publica relatorio de testes
         if: failure()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ curl -s localhost:8080/auth/login -H 'Content-Type: application/json' \
 
 | Método | Rota | Quem pode |
 |---|---|---|
+| `GET` | `/v3/api-docs` | público (contrato OpenAPI) |
 | `POST` | `/auth/login` | público |
 | `POST` | `/ideas` | qualquer autenticado |
 | `GET` | `/ideas?status=` | autenticado — `OPERADOR` só vê as próprias |

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -130,6 +136,48 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>pre-integration-test</id>
+						<goals>
+							<goal>start</goal>
+						</goals>
+						<configuration>
+							<useTestClasspath>true</useTestClasspath>
+							<profiles>
+								<profile>openapi</profile>
+							</profiles>
+							<environmentVariables>
+								<JWT_SECRET>segredo-de-teste-com-mais-de-32-bytes-para-hs256</JWT_SECRET>
+							</environmentVariables>
+						</configuration>
+					</execution>
+					<execution>
+						<id>post-integration-test</id>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.springdoc</groupId>
+				<artifactId>springdoc-openapi-maven-plugin</artifactId>
+				<version>1.4</version>
+				<executions>
+					<execution>
+						<id>generate-openapi</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<apiDocsUrl>http://localhost:8080/v3/api-docs</apiDocsUrl>
+					<outputFileName>openapi.json</outputFileName>
+					<outputDir>${project.build.directory}</outputDir>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/login").permitAll()
+                        .requestMatchers("/v3/api-docs", "/v3/api-docs/**").permitAll()
                         // Publica para o healthcheck do compose (#12) conseguir bater sem token.
                         .requestMatchers("/actuator/health").permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/MetricsPatchRequest.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/MetricsPatchRequest.java
@@ -1,5 +1,6 @@
 package br.com.fiap.aguiabranca.domain.project;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.math.BigDecimal;
 
 /**
@@ -8,6 +9,7 @@ import java.math.BigDecimal;
  */
 public record MetricsPatchRequest(Integer progress, BigDecimal spent) {
 
+    @JsonIgnore
     public boolean isEmpty() {
         return progress == null && spent == null;
     }

--- a/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectStatus.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/project/ProjectStatus.java
@@ -1,11 +1,14 @@
 package br.com.fiap.aguiabranca.domain.project;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Ciclo de vida do projeto.
  *
  * Os nomes sao contrato com o app (#24): o cliente desserializa direto neste enum, entao
  * renomear um valor quebra a tela de filtro sem aviso.
  */
+@Schema(enumAsRef = true)
 public enum ProjectStatus {
     PLANNING,
     IN_PROGRESS,

--- a/src/main/java/br/com/fiap/aguiabranca/shared/OpenApiConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/OpenApiConfig.java
@@ -1,0 +1,45 @@
+package br.com.fiap.aguiabranca.shared;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI hubOpenApi() {
+        OpenAPI api = new OpenAPI()
+                .info(new Info()
+                        .title("Hub de Inovação — Águia Branca")
+                        .version("0.0.1")
+                        .description("""
+                                API do hub. Autenticacao Bearer JWT (claim `role`).
+                                Tres perfis: OPERADOR (submete e acompanha o que e seu), \
+                                GESTOR (revisa e toca projeto) e LIDERANCA (enxerga tudo e define estrategia).
+                                """))
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", bearer("Access token JWT HS256."))
+                        .addSecuritySchemes("operador", bearer("Perfil OPERADOR."))
+                        .addSecuritySchemes("gestor", bearer("Perfil GESTOR."))
+                        .addSecuritySchemes("lideranca", bearer("Perfil LIDERANCA.")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+        api.setExtensions(new LinkedHashMap<>(Map.of("x-roles", List.of("OPERADOR", "GESTOR", "LIDERANCA"))));
+        return api;
+    }
+
+    private static SecurityScheme bearer(String description) {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description(description);
+    }
+}

--- a/src/main/resources/application-openapi.yml
+++ b/src/main/resources/application-openapi.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:openapi;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+  flyway:
+    enabled: false
+
+app:
+  jwt:
+    secret: ${JWT_SECRET:segredo-de-teste-com-mais-de-32-bytes-para-hs256}

--- a/src/test/java/br/com/fiap/aguiabranca/shared/OpenApiIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/shared/OpenApiIntegrationTest.java
@@ -1,0 +1,37 @@
+package br.com.fiap.aguiabranca.shared;
+
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OpenApiIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("/v3/api-docs e publico e descreve JWT, os tres perfis e valores financeiros como number")
+    void shouldExposeOpenApiContract() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.components.securitySchemes.bearer-jwt.type").value("http"))
+                .andExpect(jsonPath("$.components.securitySchemes.bearer-jwt.scheme").value("bearer"))
+                .andExpect(jsonPath("$.components.securitySchemes.operador.scheme").value("bearer"))
+                .andExpect(jsonPath("$.components.securitySchemes.gestor.scheme").value("bearer"))
+                .andExpect(jsonPath("$.components.securitySchemes.lideranca.scheme").value("bearer"))
+                .andExpect(jsonPath("$.components.schemas.ProjectStatus.enum",
+                        hasItems("PLANNING", "IN_PROGRESS", "COMPLETED", "CANCELLED")))
+                .andExpect(jsonPath("$.components.schemas.ProjectResponse.properties.status['$ref']")
+                        .value("#/components/schemas/ProjectStatus"))
+                .andExpect(jsonPath("$.components.schemas.ProjectResponse.properties.budget.type")
+                        .value("number"))
+                .andExpect(jsonPath("$.components.schemas.ProjectResponse.properties.spent.type")
+                        .value("number"))
+                .andExpect(jsonPath("$.info.description").value(org.hamcrest.Matchers.containsString("OPERADOR")))
+                .andExpect(jsonPath("$.info.description").value(org.hamcrest.Matchers.containsString("GESTOR")))
+                .andExpect(jsonPath("$.info.description")
+                        .value(org.hamcrest.Matchers.containsString("LIDERANCA")));
+    }
+}


### PR DESCRIPTION
## O que muda

`springdoc-openapi` no build. `GET /v3/api-docs` é público. O plugin gera `target/openapi.json` no `verify` (app sobe no profile `openapi` com H2 só para isso) e o CI publica o artefato.

Closes #20

## Como validar

```
./mvnw -q clean verify
# o JSON fica em target/openapi.json e, no GitHub Actions, no artefato `openapi`
```

## Checklist

- [x] `./mvnw -q verify` passa localmente
- [x] Commits no padrão Conventional Commits
- [x] Sem segredo, token ou credencial no diff
- [x] Migration nova é idempotente e não roda em produção sem querer
- [x] Mudança de contrato de API está refletida no `README.md` / `api.http`
- [ ] Se quebra o app Android, a issue correspondente em `area:android` foi aberta

## Risco

`/v3/api-docs` passa a ser público — é o contrato, não dado. Rollback: reverter o PR. O profile `openapi` não entra em produção.

Made with [Cursor](https://cursor.com)