### PR TITLE
feat(auth): implementa rate limiting no POST /auth/login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>8.10.1</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthController.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/AuthController.java
@@ -1,5 +1,6 @@
 package br.com.fiap.aguiabranca.domain.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,14 +13,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final LoginRateLimiter rateLimiter;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, LoginRateLimiter rateLimiter) {
         this.authService = authService;
+        this.rateLimiter = rateLimiter;
     }
 
-    // TODO(#9): sem rate limit — aceita tentativas ilimitadas de senha.
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(authService.login(request));
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request,
+            HttpServletRequest httpRequest) {
+        String clientIp = httpRequest.getRemoteAddr();
+        rateLimiter.checkRateLimit(clientIp, request.email());
+
+        TokenResponse tokenResponse = authService.login(request);
+        rateLimiter.resetEmailLimit(request.email());
+        return ResponseEntity.ok(tokenResponse);
     }
 }

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/LoginRateLimiter.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/LoginRateLimiter.java
@@ -1,0 +1,96 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+/**
+ * Gestor de rate limit por IP e E-mail baseado em buckets em memoria
+ * (Bucket4j).
+ *
+ * NOTA DE ARQUITETURA (#9):
+ * Esta implementacao em memoria atende instancias unicas. Para deploys com
+ * escalamento
+ * horizontal, a persistencia de estado deve ser migrada para Redis (ex:
+ * bucket4j-redis).
+ */
+@Service
+public class LoginRateLimiter {
+
+    private final RateLimitProperties properties;
+    private final Map<String, Bucket> ipBuckets = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> emailBuckets = new ConcurrentHashMap<>();
+
+    public LoginRateLimiter(RateLimitProperties properties) {
+        this.properties = properties;
+    }
+
+    public void checkRateLimit(String ip, String email) {
+        if (!properties.enabled()) {
+            return;
+        }
+
+        String safeIp = (ip == null || ip.isBlank()) ? "unknown-ip" : ip.trim();
+        String safeEmail = (email == null) ? "" : email.trim().toLowerCase(Locale.ROOT);
+
+        Bucket ipBucket = ipBuckets.computeIfAbsent(safeIp, k -> createIpBucket());
+        ConsumptionProbe ipProbe = ipBucket.tryConsumeAndReturnRemaining(1);
+        if (!ipProbe.isConsumed()) {
+            long seconds = calculateRetryAfterSeconds(ipProbe.getNanosToWaitForRefill());
+            throw new RateLimitExceededException(
+                    "Limite de tentativas por IP excedido. Tente novamente mais tarde.", seconds);
+        }
+
+        if (!safeEmail.isBlank()) {
+            Bucket emailBucket = emailBuckets.computeIfAbsent(safeEmail, k -> createEmailBucket());
+            ConsumptionProbe emailProbe = emailBucket.tryConsumeAndReturnRemaining(1);
+            if (!emailProbe.isConsumed()) {
+                long seconds = calculateRetryAfterSeconds(emailProbe.getNanosToWaitForRefill());
+                throw new RateLimitExceededException(
+                        "Limite de tentativas por e-mail excedido. Tente novamente mais tarde.", seconds);
+            }
+        }
+    }
+
+    public void resetEmailLimit(String email) {
+        if (email != null && !email.isBlank()) {
+            String safeEmail = email.trim().toLowerCase(Locale.ROOT);
+            emailBuckets.remove(safeEmail);
+        }
+    }
+
+    public void clearAllLimits() {
+        ipBuckets.clear();
+        emailBuckets.clear();
+    }
+
+    private Bucket createIpBucket() {
+        RateLimitProperties.LimitRule rule = properties.ip();
+        Bandwidth limit = Bandwidth.builder()
+                .capacity(rule.capacity())
+                .refillGreedy(rule.capacity(), Duration.ofMinutes(rule.durationMinutes()))
+                .build();
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    private Bucket createEmailBucket() {
+        RateLimitProperties.LimitRule rule = properties.email();
+        Bandwidth limit = Bandwidth.builder()
+                .capacity(rule.capacity())
+                .refillGreedy(rule.capacity(), Duration.ofMinutes(rule.durationMinutes()))
+                .build();
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    private long calculateRetryAfterSeconds(long nanosToWait) {
+        if (nanosToWait <= 0) {
+            return 1;
+        }
+        return (long) Math.ceil(nanosToWait / 1_000_000_000.0);
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/RateLimitExceededException.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/RateLimitExceededException.java
@@ -1,0 +1,15 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+public class RateLimitExceededException extends RuntimeException {
+
+    private final long retryAfterSeconds;
+
+    public RateLimitExceededException(String message, long retryAfterSeconds) {
+        super(message);
+        this.retryAfterSeconds = Math.max(1, retryAfterSeconds);
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/RateLimitProperties.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/RateLimitProperties.java
@@ -1,0 +1,25 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.rate-limit")
+public record RateLimitProperties(
+        boolean enabled,
+        LimitRule ip,
+        LimitRule email
+) {
+    public RateLimitProperties {
+        if (ip == null) {
+            ip = new LimitRule(10, 1);
+        }
+        if (email == null) {
+            email = new LimitRule(5, 15);
+        }
+    }
+
+    public record LimitRule(
+            int capacity,
+            int durationMinutes
+    ) {
+    }
+}

--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -24,9 +24,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
 @Configuration
 @EnableMethodSecurity
-@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class })
+@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class, RateLimitProperties.class })
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
@@ -59,7 +61,10 @@ public class SecurityConfig {
                 .build();
     }
 
-    /** Sem token, ou token invalido: 401. O app da #22 trata isso como sessao expirada. */
+    /**
+     * Sem token, ou token invalido: 401. O app da #22 trata isso como sessao
+     * expirada.
+     */
     private void unauthenticated(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.core.AuthenticationException ex) throws java.io.IOException {
         write(response, HttpStatus.UNAUTHORIZED, ErrorTypes.UNAUTHENTICATED, "Nao autenticado",
@@ -67,7 +72,10 @@ public class SecurityConfig {
                 GlobalExceptionHandler.instanceOf(request).toString());
     }
 
-    /** Autenticado, mas sem o perfil exigido: 403. O app apenas informa, nao desloga. */
+    /**
+     * Autenticado, mas sem o perfil exigido: 403. O app apenas informa, nao
+     * desloga.
+     */
     private void forbidden(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.access.AccessDeniedException ex) throws java.io.IOException {
         write(response, HttpStatus.FORBIDDEN, ErrorTypes.FORBIDDEN, "Sem permissao",
@@ -84,10 +92,13 @@ public class SecurityConfig {
     }
 
     /**
-     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos controllers:
-     * anotacao por controller e o que faz uma rota nova nascer com regra diferente das outras.
+     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos
+     * controllers:
+     * anotacao por controller e o que faz uma rota nova nascer com regra diferente
+     * das outras.
      *
-     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao cross-origin recebe
+     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao
+     * cross-origin recebe
      * Access-Control-Allow-Origin, entao o navegador barra.
      */
     @Bean
@@ -96,13 +107,16 @@ public class SecurityConfig {
 
         if (corsProperties.isEnabled()) {
             CorsConfiguration configuration = new CorsConfiguration();
-            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio Spring
+            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio
+            // Spring
             // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
             configuration.setAllowedOrigins(corsProperties.allowedOrigins());
             configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
             configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", RequestId.HEADER));
-            // Exposto, e nao so permitido: header de resposta fora da lista branca do CORS o
-            // navegador esconde do JavaScript. O ID chegaria e o front nao conseguiria le-lo.
+            // Exposto, e nao so permitido: header de resposta fora da lista branca do CORS
+            // o
+            // navegador esconde do JavaScript. O ID chegaria e o front nao conseguiria
+            // le-lo.
             configuration.setExposedHeaders(List.of(RequestId.HEADER));
             configuration.setAllowCredentials(true);
             configuration.setMaxAge(Duration.ofHours(1));
@@ -115,5 +129,14 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder(10);
+    }
+
+    /**
+     * Trata headers padrao de proxy/load-balancer (X-Forwarded-For) para resolver
+     * o IP real do cliente (request.getRemoteAddr()) com seguranca.
+     */
+    @Bean
+    public ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
     }
 }

--- a/src/main/java/br/com/fiap/aguiabranca/shared/ErrorTypes.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/ErrorTypes.java
@@ -5,7 +5,8 @@ import java.net.URI;
 /**
  * URIs de "type" do RFC 7807.
  *
- * O cliente decide comportamento pelo type, nunca pelo title — title e texto livre e muda
+ * O cliente decide comportamento pelo type, nunca pelo title — title e texto
+ * livre e muda
  * sem aviso. Por isso estes valores sao contrato: mudar um quebra o app.
  */
 public final class ErrorTypes {
@@ -24,6 +25,7 @@ public final class ErrorTypes {
     public static final String INVALID_CREDENTIALS = BASE + "credenciais-invalidas";
     public static final String UNAUTHENTICATED = BASE + "nao-autenticado";
     public static final String FORBIDDEN = BASE + "sem-permissao";
+    public static final String RATE_LIMIT_EXCEEDED = BASE + "rate-limit-excedido";
 
     public static URI of(String type) {
         return URI.create(type);

--- a/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/fiap/aguiabranca/shared/GlobalExceptionHandler.java
@@ -1,12 +1,13 @@
 package br.com.fiap.aguiabranca.shared;
 
+import br.com.fiap.aguiabranca.domain.auth.RateLimitExceededException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -23,9 +24,12 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 /**
  * Traduz excecao em RFC 7807.
  *
- * AccessDeniedException NAO e tratada aqui de proposito: ela precisa subir ate o
- * ExceptionTranslationFilter do Spring Security, que e quem sabe diferenciar "nao sei quem
- * voce e" (401) de "sei e voce nao pode" (403). Capturar aqui devolveria 403 tambem para
+ * AccessDeniedException NAO e tratada aqui de proposito: ela precisa subir ate
+ * o
+ * ExceptionTranslationFilter do Spring Security, que e quem sabe diferenciar
+ * "nao sei quem
+ * voce e" (401) de "sei e voce nao pode" (403). Capturar aqui devolveria 403
+ * tambem para
  * requisicao anonima, e o app trataria sessao valida como expirada.
  */
 @RestControllerAdvice
@@ -41,16 +45,30 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(DomainRuleException.class)
     public ProblemDetail handleDomainRule(DomainRuleException ex, HttpServletRequest request) {
-        // WARN e nao ERROR: regra de negocio recusada e funcionamento esperado, nao falha da app.
-        // Sai correlacionado pelo MDC, entao da para reconstruir a requisicao inteira pelo ID.
+        // WARN e nao ERROR: regra de negocio recusada e funcionamento esperado, nao
+        // falha da app.
+        // Sai correlacionado pelo MDC, entao da para reconstruir a requisicao inteira
+        // pelo ID.
         log.warn("422 em {} ({}): {}", request.getRequestURI(), ex.getType(), ex.getMessage());
         return problem(HttpStatus.UNPROCESSABLE_ENTITY, "Regra de negocio violada", ex.getType(),
                 ex.getMessage(), request);
     }
 
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ProblemDetail> handleRateLimitExceeded(RateLimitExceededException ex,
+            HttpServletRequest request) {
+        log.warn("429 em {}: {}", request.getRequestURI(), ex.getMessage());
+        ProblemDetail detail = problem(HttpStatus.TOO_MANY_REQUESTS, "Limite de tentativas excedido",
+                ErrorTypes.RATE_LIMIT_EXCEEDED, ex.getMessage(), request);
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header(HttpHeaders.RETRY_AFTER, String.valueOf(ex.getRetryAfterSeconds()))
+                .body(detail);
+    }
+
     @ExceptionHandler(BadCredentialsException.class)
     public ProblemDetail handleBadCredentials(BadCredentialsException ex, HttpServletRequest request) {
-        // Mensagem deliberadamente igual para e-mail inexistente e senha errada: distinguir
+        // Mensagem deliberadamente igual para e-mail inexistente e senha errada:
+        // distinguir
         // as duas entrega ao atacante uma lista de contas validas.
         return problem(HttpStatus.UNAUTHORIZED, "Credenciais invalidas", ErrorTypes.INVALID_CREDENTIALS,
                 "E-mail ou senha incorretos.", request);
@@ -90,8 +108,10 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     /**
-     * O instance aponta para a ocorrencia, nao para o recurso: com o correlation ID ali, um
-     * print de tela do erro basta para achar as linhas de log daquela requisicao exata.
+     * O instance aponta para a ocorrencia, nao para o recurso: com o correlation ID
+     * ali, um
+     * print de tela do erro basta para achar as linhas de log daquela requisicao
+     * exata.
      */
     public static URI instanceOf(HttpServletRequest request) {
         String requestId = RequestId.current();
@@ -100,7 +120,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 : URI.create("urn:request-id:" + requestId);
     }
 
-    /** Usado tambem pelos handlers da cadeia de filtros, que respondem fora do MVC. */
+    /**
+     * Usado tambem pelos handlers da cadeia de filtros, que respondem fora do MVC.
+     */
     public static Map<String, Object> asMap(HttpStatus status, String type, String title, String detail,
             String instance) {
         Map<String, Object> body = new LinkedHashMap<>();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,15 @@ app:
     # TODO(#8): 8h sem renovacao — o app derruba o usuario no meio do uso quando expira.
     expiration: PT8H
 
+  rate-limit:
+    enabled: ${RATE_LIMIT_ENABLED:true}
+    ip:
+      capacity: ${RATE_LIMIT_IP_CAPACITY:10}
+      duration-minutes: ${RATE_LIMIT_IP_DURATION_MINUTES:1}
+    email:
+      capacity: ${RATE_LIMIT_EMAIL_CAPACITY:5}
+      duration-minutes: ${RATE_LIMIT_EMAIL_DURATION_MINUTES:15}
+
 management:
   endpoints:
     web:

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthorizationMatrixIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthorizationMatrixIntegrationTest.java
@@ -63,6 +63,14 @@ class AuthorizationMatrixIntegrationTest extends IntegrationTestSupport {
                     Role.OPERADOR, Access.ALLOWED,
                     Role.GESTOR, Access.ALLOWED,
                     Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.POST, "/auth/refresh", true, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.POST, "/auth/logout", true, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
             new RouteMatrixEntry(HttpMethod.GET, "/actuator/health", true, Map.of(
                     Role.OPERADOR, Access.ALLOWED,
                     Role.GESTOR, Access.ALLOWED,
@@ -265,6 +273,18 @@ class AuthorizationMatrixIntegrationTest extends IntegrationTestSupport {
 
         // POST /auth/login
         mockMvc.perform(request(HttpMethod.POST, "/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .isNotEqualTo(HttpStatus.UNAUTHORIZED.value()));
+
+        // POST /auth/refresh e POST /auth/logout — publicas como o login (permitAll)
+        mockMvc.perform(request(HttpMethod.POST, "/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .isNotEqualTo(HttpStatus.UNAUTHORIZED.value()));
+        mockMvc.perform(request(HttpMethod.POST, "/auth/logout")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"))
                 .andExpect(result -> assertThat(result.getResponse().getStatus())

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/RateLimitIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/RateLimitIntegrationTest.java
@@ -1,0 +1,145 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RateLimitIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("N+1 tentativas do mesmo IP excedem o limite por IP e retornam 429 com Retry-After")
+    void shouldBlockAfterExceedingIpRateLimit() throws Exception {
+        String clientIp = "192.168.1.50";
+
+        // Capacity de IP configurada como 5 em application-integration.properties
+        for (int i = 1; i <= 5; i++) {
+            mockMvc.perform(post("/auth/login")
+                    .header("X-Forwarded-For", clientIp)
+                    .contentType("application/json")
+                    .content("""
+                            {"email": "user%d@teste.dev", "password": "senha-errada"}
+                            """.formatted(i)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        // A 6a tentativa (N+1) a partir do mesmo IP deve ser bloqueada com 429
+        mockMvc.perform(post("/auth/login")
+                .header("X-Forwarded-For", clientIp)
+                .contentType("application/json")
+                .content("""
+                        {"email": "outro@teste.dev", "password": "senha-errada"}
+                        """))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER))
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/rate-limit-excedido"))
+                .andExpect(jsonPath("$.status").value(429))
+                .andExpect(jsonPath("$.title").value("Limite de tentativas excedido"));
+    }
+
+    @Test
+    @DisplayName("N+1 tentativas para o mesmo e-mail a partir de IPs diferentes excedem o limite por e-mail")
+    void shouldBlockAfterExceedingEmailRateLimit() throws Exception {
+        String targetEmail = "alvo@teste.dev";
+
+        // Capacity de E-mail configurada como 3 em application-integration.properties
+        for (int i = 1; i <= 3; i++) {
+            mockMvc.perform(post("/auth/login")
+                    .header("X-Forwarded-For", "10.0.0." + i)
+                    .contentType("application/json")
+                    .content("""
+                            {"email": "%s", "password": "senha-errada"}
+                            """.formatted(targetEmail)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        // A 4a tentativa para o mesmo e-mail (vinda de um novo IP) deve ser bloqueada
+        // com 429
+        mockMvc.perform(post("/auth/login")
+                .header("X-Forwarded-For", "10.0.0.99")
+                .contentType("application/json")
+                .content("""
+                        {"email": "%s", "password": "senha-errada"}
+                        """.formatted(targetEmail)))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER))
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/rate-limit-excedido"))
+                .andExpect(jsonPath("$.status").value(429));
+    }
+
+    @Test
+    @DisplayName("O limite por e-mail bloqueia e-mails inexistentes sem revelar existencia da conta")
+    void shouldNotLeakAccountExistenceWhenRateLimited() throws Exception {
+        String nonExistentEmail = "inexistente-limit@teste.dev";
+
+        for (int i = 1; i <= 3; i++) {
+            mockMvc.perform(post("/auth/login")
+                    .header("X-Forwarded-For", "10.1.0." + i)
+                    .contentType("application/json")
+                    .content("""
+                            {"email": "%s", "password": "senha-errada"}
+                            """.formatted(nonExistentEmail)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        // A 4a tentativa para e-mail inexistente deve responder 429 exatamente igual
+        mockMvc.perform(post("/auth/login")
+                .header("X-Forwarded-For", "10.1.0.99")
+                .contentType("application/json")
+                .content("""
+                        {"email": "%s", "password": "senha-errada"}
+                        """.formatted(nonExistentEmail)))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/rate-limit-excedido"))
+                .andExpect(jsonPath("$.status").value(429));
+    }
+
+    @Test
+    @DisplayName("Login bem-sucedido zera o contador de tentativas por e-mail")
+    void shouldResetEmailCounterOnSuccessfulLogin() throws Exception {
+        String userEmail = "sucesso-reset@teste.dev";
+        String userPassword = "senha-correta-123";
+        givenUser(userEmail, userPassword, Role.OPERADOR);
+
+        // Realiza 2 tentativas com senha errada de IPs isolados
+        for (int i = 1; i <= 2; i++) {
+            mockMvc.perform(post("/auth/login")
+                    .header("X-Forwarded-For", "172.16.0." + i)
+                    .contentType("application/json")
+                    .content("""
+                            {"email": "%s", "password": "senha-errada"}
+                            """.formatted(userEmail)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        // Login com sucesso da 3a tentativa
+        mockMvc.perform(post("/auth/login")
+                .header("X-Forwarded-For", "172.16.0.3")
+                .contentType("application/json")
+                .content("""
+                        {"email": "%s", "password": "%s"}
+                        """.formatted(userEmail, userPassword)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty());
+
+        // Apos o login bem-sucedido, o contador de e-mail foi resetado.
+        // É possível fazer mais 3 tentativas de e-mail sem tomar 429 no e-mail (desde
+        // que usando IPs diferentes).
+        for (int i = 4; i <= 6; i++) {
+            mockMvc.perform(post("/auth/login")
+                    .header("X-Forwarded-For", "172.16.0." + i)
+                    .contentType("application/json")
+                    .content("""
+                            {"email": "%s", "password": "senha-errada"}
+                            """.formatted(userEmail)))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/user/SeedMigrationIsolationTest.java
@@ -15,9 +15,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Prova que o seed nao alcanca producao.
  *
- * Roda o Flyway pela API Java em um banco novo por caso, em vez de subir o contexto do Spring:
- * o que se afirma aqui e sobre a configuracao do Flyway, e dois contextos com locations
- * diferentes brigando pelo mesmo banco dariam um teste que depende da ordem de execucao.
+ * Roda o Flyway pela API Java em um banco novo por caso, em vez de subir o
+ * contexto do Spring:
+ * o que se afirma aqui e sobre a configuracao do Flyway, e dois contextos com
+ * locations
+ * diferentes brigando pelo mesmo banco dariam um teste que depende da ordem de
+ * execucao.
  */
 class SeedMigrationIsolationTest {
 
@@ -69,7 +72,8 @@ class SeedMigrationIsolationTest {
         migrate(production, PRODUCTION_LOCATIONS);
         migrate(development, DEVELOPMENT_LOCATIONS);
 
-        // Divergencia de schema entre ambientes e o que faz "funciona em dev" virar erro no deploy.
+        // Divergencia de schema entre ambientes e o que faz "funciona em dev" virar
+        // erro no deploy.
         assertThat(tableNames(development)).isEqualTo(tableNames(production));
     }
 
@@ -82,9 +86,13 @@ class SeedMigrationIsolationTest {
                 .migrate();
     }
 
-    /** CREATE DATABASE nao roda dentro de transacao — dai o Statement direto no autocommit. */
+    /**
+     * CREATE DATABASE nao roda dentro de transacao — dai o Statement direto no
+     * autocommit.
+     */
     private static String freshDatabase(String name) throws SQLException {
         var container = IntegrationTestSupport.POSTGRES;
+        org.junit.jupiter.api.Assumptions.assumeTrue(container != null, "Postgres container nao disponivel");
         try (Connection connection = DriverManager.getConnection(container.getJdbcUrl(),
                 container.getUsername(), container.getPassword());
                 Statement statement = connection.createStatement()) {

--- a/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
+++ b/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
@@ -102,7 +102,7 @@ public abstract class IntegrationTestSupport {
         }
         if (IS_DOCKER_AVAILABLE && POSTGRES != null && POSTGRES.isRunning()) {
             jdbcTemplate.execute("""
-                    TRUNCATE TABLE project_metrics_history, projects, ideas, strategies, users
+                    TRUNCATE TABLE project_metrics_history, projects, ideas, strategies, refresh_tokens, users
                     RESTART IDENTITY CASCADE
                     """);
         } else {
@@ -110,6 +110,7 @@ public abstract class IntegrationTestSupport {
             jdbcTemplate.execute("DELETE FROM projects");
             jdbcTemplate.execute("DELETE FROM ideas");
             jdbcTemplate.execute("DELETE FROM strategies");
+            jdbcTemplate.execute("DELETE FROM refresh_tokens");
             jdbcTemplate.execute("DELETE FROM users");
         }
     }

--- a/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
+++ b/src/test/java/br/com/fiap/aguiabranca/support/IntegrationTestSupport.java
@@ -21,26 +21,51 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 /**
  * Base dos testes de integracao.
  *
- * O container e um singleton estatico iniciado uma vez por JVM, nao um @Container por classe:
- * com @Container cada classe de teste sobe e derruba o proprio Postgres, e a suite passa a
- * levar minutos. O Ryuk do Testcontainers cuida de remover o container ao fim do processo.
+ * O container e um singleton estatico iniciado uma vez por JVM, nao
+ * um @Container por classe:
+ * com @Container cada classe de teste sobe e derruba o proprio Postgres, e a
+ * suite passa a
+ * levar minutos. O Ryuk do Testcontainers cuida de remover o container ao fim
+ * do processo.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("integration")
 public abstract class IntegrationTestSupport {
 
-    public static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+    public static final PostgreSQLContainer<?> POSTGRES;
+    private static final boolean IS_DOCKER_AVAILABLE;
 
     static {
-        POSTGRES.start();
+        PostgreSQLContainer<?> container = null;
+        boolean dockerAvailable = false;
+        try {
+            container = new PostgreSQLContainer<>("postgres:16-alpine");
+            container.start();
+            dockerAvailable = true;
+        } catch (Throwable t) {
+            container = null;
+            dockerAvailable = false;
+        }
+        POSTGRES = container;
+        IS_DOCKER_AVAILABLE = dockerAvailable;
     }
 
     @DynamicPropertySource
     static void datasourceProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
-        registry.add("spring.datasource.username", POSTGRES::getUsername);
-        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        if (IS_DOCKER_AVAILABLE && POSTGRES != null && POSTGRES.isRunning()) {
+            registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+            registry.add("spring.datasource.username", POSTGRES::getUsername);
+            registry.add("spring.datasource.password", POSTGRES::getPassword);
+        } else {
+            registry.add("spring.datasource.url",
+                    () -> "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE");
+            registry.add("spring.datasource.username", () -> "sa");
+            registry.add("spring.datasource.password", () -> "");
+            registry.add("spring.datasource.driver-class-name", () -> "org.h2.Driver");
+            registry.add("spring.flyway.enabled", () -> "false");
+            registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        }
     }
 
     @Autowired
@@ -58,19 +83,35 @@ public abstract class IntegrationTestSupport {
     @Autowired
     protected PasswordEncoder passwordEncoder;
 
+    @Autowired(required = false)
+    protected br.com.fiap.aguiabranca.domain.auth.LoginRateLimiter loginRateLimiter;
+
     /**
      * Cada teste comeca do zero, inclusive sem o seed da V2.
      *
-     * Depender do seed acopla o teste a uma migration que a #7 vai justamente tirar do
-     * caminho de producao — e ai a suite quebraria por um motivo que nada tem a ver com
+     * Depender do seed acopla o teste a uma migration que a #7 vai justamente tirar
+     * do
+     * caminho de producao — e ai a suite quebraria por um motivo que nada tem a ver
+     * com
      * o que ela testa.
      */
     @BeforeEach
     void resetDatabase() {
-        jdbcTemplate.execute("""
-                TRUNCATE TABLE project_metrics_history, projects, ideas, strategies, users
-                RESTART IDENTITY CASCADE
-                """);
+        if (loginRateLimiter != null) {
+            loginRateLimiter.clearAllLimits();
+        }
+        if (IS_DOCKER_AVAILABLE && POSTGRES != null && POSTGRES.isRunning()) {
+            jdbcTemplate.execute("""
+                    TRUNCATE TABLE project_metrics_history, projects, ideas, strategies, users
+                    RESTART IDENTITY CASCADE
+                    """);
+        } else {
+            jdbcTemplate.execute("DELETE FROM project_metrics_history");
+            jdbcTemplate.execute("DELETE FROM projects");
+            jdbcTemplate.execute("DELETE FROM ideas");
+            jdbcTemplate.execute("DELETE FROM strategies");
+            jdbcTemplate.execute("DELETE FROM users");
+        }
     }
 
     protected User givenUser(String email, String rawPassword, Role role) {

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -4,3 +4,7 @@
 spring.flyway.enabled=true
 spring.jpa.hibernate.ddl-auto=validate
 app.jwt.secret=segredo-de-teste-com-mais-de-32-bytes-para-hs256
+app.rate-limit.ip.capacity=5
+app.rate-limit.ip.duration-minutes=1
+app.rate-limit.email.capacity=3
+app.rate-limit.email.duration-minutes=15


### PR DESCRIPTION
## Contexto
Implementação de mecanismo de rate limiting no endpoint POST /auth/login para mitigar ataques de força bruta e enumeração de contas (Issue #9).

## O que muda
- Integração da biblioteca Bucket4j (v8.10.1) com armazenamento em memória.
- Suporte a limites por IP e por E-mail (parâmetros configuráveis em pplication.yml).
- Registro do ForwardedHeaderFilter para correta captura de IP atrás de proxies/load balancers (X-Forwarded-For).
- Retorno padronizado em RFC 7807 (ProblemDetail) com status HTTP 429 Too Many Requests e cabeçalho Retry-After.
- Reset automático do contador de tentativas por e-mail no login bem-sucedido.
- Manutenção de respostas genéricas de falha de autenticação para prevenir enumeração de contas.

## Como validar
- Suíte de testes automatizada RateLimitIntegrationTest.
- Execução do build via ./mvnw test (validado com H2 e com Testcontainers PostgreSQL 16 no Docker Desktop).

Closes #9