### PR TITLE
test(security): matriz de autorizacao por perfil (closes #18)

### DIFF
--- a/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
+++ b/src/main/java/br/com/fiap/aguiabranca/domain/auth/SecurityConfig.java
@@ -51,6 +51,20 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login").permitAll()
                         // Publica para o healthcheck do compose (#12) conseguir bater sem token.
                         .requestMatchers("/actuator/health").permitAll()
+                        // Restrições RBAC definidas aqui (nível de URL) em vez de apenas @PreAuthorize,
+                        // para que o Spring Security retorne 403 ANTES que @Valid dispare 422.
+                        .requestMatchers(org.springframework.http.HttpMethod.POST, "/ideas/*/approval")
+                        .hasAnyRole("GESTOR", "LIDERANCA")
+                        .requestMatchers(org.springframework.http.HttpMethod.POST, "/projects/from-idea/*")
+                        .hasAnyRole("GESTOR", "LIDERANCA")
+                        .requestMatchers(org.springframework.http.HttpMethod.PATCH, "/projects/*/metrics")
+                        .hasAnyRole("GESTOR", "LIDERANCA")
+                        .requestMatchers(org.springframework.http.HttpMethod.POST, "/strategies")
+                        .hasAnyRole("GESTOR", "LIDERANCA")
+                        .requestMatchers(org.springframework.http.HttpMethod.PUT, "/strategies/*")
+                        .hasAnyRole("GESTOR", "LIDERANCA")
+                        .requestMatchers(org.springframework.http.HttpMethod.DELETE, "/strategies/*")
+                        .hasAnyRole("GESTOR", "LIDERANCA")
                         .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(this::unauthenticated)
@@ -59,7 +73,10 @@ public class SecurityConfig {
                 .build();
     }
 
-    /** Sem token, ou token invalido: 401. O app da #22 trata isso como sessao expirada. */
+    /**
+     * Sem token, ou token invalido: 401. O app da #22 trata isso como sessao
+     * expirada.
+     */
     private void unauthenticated(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.core.AuthenticationException ex) throws java.io.IOException {
         write(response, HttpStatus.UNAUTHORIZED, ErrorTypes.UNAUTHENTICATED, "Nao autenticado",
@@ -67,7 +84,10 @@ public class SecurityConfig {
                 GlobalExceptionHandler.instanceOf(request).toString());
     }
 
-    /** Autenticado, mas sem o perfil exigido: 403. O app apenas informa, nao desloga. */
+    /**
+     * Autenticado, mas sem o perfil exigido: 403. O app apenas informa, nao
+     * desloga.
+     */
     private void forbidden(HttpServletRequest request, HttpServletResponse response,
             org.springframework.security.access.AccessDeniedException ex) throws java.io.IOException {
         write(response, HttpStatus.FORBIDDEN, ErrorTypes.FORBIDDEN, "Sem permissao",
@@ -84,10 +104,13 @@ public class SecurityConfig {
     }
 
     /**
-     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos controllers:
-     * anotacao por controller e o que faz uma rota nova nascer com regra diferente das outras.
+     * Um unico ponto de configuracao, no lugar de @CrossOrigin espalhado pelos
+     * controllers:
+     * anotacao por controller e o que faz uma rota nova nascer com regra diferente
+     * das outras.
      *
-     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao cross-origin recebe
+     * Sem origem configurada devolve uma fonte vazia — nenhuma requisicao
+     * cross-origin recebe
      * Access-Control-Allow-Origin, entao o navegador barra.
      */
     @Bean
@@ -96,13 +119,16 @@ public class SecurityConfig {
 
         if (corsProperties.isEnabled()) {
             CorsConfiguration configuration = new CorsConfiguration();
-            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio Spring
+            // Lista explicita, nunca "*": combinado com allowCredentials(true) o proprio
+            // Spring
             // recusa o curinga em runtime, e o header sai ecoando a origem que pediu.
             configuration.setAllowedOrigins(corsProperties.allowedOrigins());
             configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
             configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", RequestId.HEADER));
-            // Exposto, e nao so permitido: header de resposta fora da lista branca do CORS o
-            // navegador esconde do JavaScript. O ID chegaria e o front nao conseguiria le-lo.
+            // Exposto, e nao so permitido: header de resposta fora da lista branca do CORS
+            // o
+            // navegador esconde do JavaScript. O ID chegaria e o front nao conseguiria
+            // le-lo.
             configuration.setExposedHeaders(List.of(RequestId.HEADER));
             configuration.setAllowCredentials(true);
             configuration.setMaxAge(Duration.ofHours(1));

--- a/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthorizationMatrixIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/auth/AuthorizationMatrixIntegrationTest.java
@@ -1,0 +1,273 @@
+package br.com.fiap.aguiabranca.domain.auth;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthorizationMatrixIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    @org.springframework.beans.factory.annotation.Qualifier("requestMappingHandlerMapping")
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    public enum Access {
+        ALLOWED,
+        FORBIDDEN
+    }
+
+    public record RouteMatrixEntry(
+            HttpMethod method,
+            String path,
+            boolean isPublic,
+            Map<Role, Access> roleAccess) {
+        public String key() {
+            return method.name() + " " + path;
+        }
+    }
+
+    // Tabela única e legível da matriz de autorização
+    private static final List<RouteMatrixEntry> MATRIX = List.of(
+            // Rotas Públicas
+            new RouteMatrixEntry(HttpMethod.POST, "/auth/login", true, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.GET, "/actuator/health", true, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+
+            // Domínio Ideas
+            new RouteMatrixEntry(HttpMethod.POST, "/ideas", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.GET, "/ideas", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.GET, "/ideas/{id}", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.POST, "/ideas/{id}/approval", false, Map.of(
+                    Role.OPERADOR, Access.FORBIDDEN,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+
+            // Domínio Projects
+            new RouteMatrixEntry(HttpMethod.GET, "/projects", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.GET, "/projects/summary", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.GET, "/projects/{id}", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.GET, "/projects/{id}/metrics-history", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.POST, "/projects/from-idea/{ideaId}", false, Map.of(
+                    Role.OPERADOR, Access.FORBIDDEN,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.PATCH, "/projects/{id}/metrics", false, Map.of(
+                    Role.OPERADOR, Access.FORBIDDEN,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+
+            // Domínio Strategies
+            new RouteMatrixEntry(HttpMethod.GET, "/strategies", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.GET, "/strategies/{id}", false, Map.of(
+                    Role.OPERADOR, Access.ALLOWED,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.POST, "/strategies", false, Map.of(
+                    Role.OPERADOR, Access.FORBIDDEN,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.PUT, "/strategies/{id}", false, Map.of(
+                    Role.OPERADOR, Access.FORBIDDEN,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)),
+            new RouteMatrixEntry(HttpMethod.DELETE, "/strategies/{id}", false, Map.of(
+                    Role.OPERADOR, Access.FORBIDDEN,
+                    Role.GESTOR, Access.ALLOWED,
+                    Role.LIDERANCA, Access.ALLOWED)));
+
+    @Test
+    @DisplayName("Garante que toda rota declarada no Spring MVC está registrada na matriz")
+    void shouldFailIfAnySpringRouteIsMissingFromMatrix() {
+        Set<String> matrixKeys = new TreeSet<>();
+        for (RouteMatrixEntry entry : MATRIX) {
+            matrixKeys.add(entry.key());
+        }
+
+        Set<String> springKeys = new TreeSet<>();
+        for (RequestMappingInfo info : handlerMapping.getHandlerMethods().keySet()) {
+            Set<String> patterns = info.getPatternValues();
+            Set<RequestMethod> methods = info.getMethodsCondition().getMethods();
+
+            for (String pattern : patterns) {
+                if (pattern.startsWith("/error")) {
+                    continue;
+                }
+                for (RequestMethod method : methods) {
+                    springKeys.add(method.name() + " " + pattern);
+                }
+            }
+        }
+
+        assertThat(springKeys)
+                .withFailMessage("Existem rotas no Spring MVC que NÃO foram declaradas na matriz de autorização: %s",
+                        springKeys.stream().filter(k -> !matrixKeys.contains(k)).toList())
+                .isSubsetOf(matrixKeys);
+    }
+
+    public record RoleTestCase(RouteMatrixEntry entry, Role role) {
+        @Override
+        public String toString() {
+            return entry.method() + " " + entry.path() + " -> " + role + " (" + entry.roleAccess().get(role) + ")";
+        }
+    }
+
+    static Stream<RoleTestCase> generateRoleTestCases() {
+        return MATRIX.stream().flatMap(entry -> Stream.of(Role.OPERADOR, Role.GESTOR, Role.LIDERANCA)
+                .map(role -> new RoleTestCase(entry, role)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("generateRoleTestCases")
+    @DisplayName("Valida acesso por perfil (20x/40x vs 403) para cada rota x perfil")
+    void shouldValidateRoleAccessForEveryRoute(RoleTestCase testCase) throws Exception {
+        RouteMatrixEntry entry = testCase.entry();
+        Role role = testCase.role();
+        Access access = entry.roleAccess().get(role);
+
+        String token = tokenFor(role.name().toLowerCase() + "@teste.dev", role);
+        String testPath = entry.path()
+                .replace("{id}", "1")
+                .replace("{ideaId}", "1");
+
+        MockHttpServletRequestBuilder requestBuilder = request(entry.method(), testPath)
+                .header(HttpHeaders.AUTHORIZATION, bearer(token))
+                .contentType(MediaType.APPLICATION_JSON);
+
+        if (entry.method() == HttpMethod.POST || entry.method() == HttpMethod.PUT
+                || entry.method() == HttpMethod.PATCH) {
+            requestBuilder.content("{}");
+        }
+
+        if (access == Access.FORBIDDEN) {
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isForbidden());
+        } else {
+            mockMvc.perform(requestBuilder)
+                    .andExpect(result -> assertThat(result.getResponse().getStatus())
+                            .isNotIn(HttpStatus.FORBIDDEN.value(), HttpStatus.UNAUTHORIZED.value()));
+        }
+    }
+
+    @Test
+    @DisplayName("Requisição sem token em rota protegida responde 401 (não 403)")
+    void shouldReturn401WhenRequestingProtectedRouteWithoutToken() throws Exception {
+        mockMvc.perform(request(HttpMethod.GET, "/ideas"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Requisição com token expirado responde 401")
+    void shouldReturn401WhenTokenIsExpired() throws Exception {
+        SecretKey key = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+        Instant past = Instant.now().minusSeconds(3600);
+
+        String expiredToken = Jwts.builder()
+                .subject("1")
+                .claim("email", "operador@teste.dev")
+                .claim("role", Role.OPERADOR.name())
+                .issuedAt(Date.from(past.minusSeconds(3600)))
+                .expiration(Date.from(past))
+                .signWith(key)
+                .compact();
+
+        mockMvc.perform(request(HttpMethod.GET, "/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(expiredToken)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Requisição com token de assinatura inválida responde 401")
+    void shouldReturn401WhenTokenHasInvalidSignature() throws Exception {
+        SecretKey invalidKey = Keys.hmacShaKeyFor(
+                "chave-falsa-com-tamanho-suficiente-para-hmac-sha-256-signature!".getBytes(StandardCharsets.UTF_8));
+        Instant now = Instant.now();
+
+        String invalidToken = Jwts.builder()
+                .subject("1")
+                .claim("email", "operador@teste.dev")
+                .claim("role", Role.OPERADOR.name())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(3600)))
+                .signWith(invalidKey)
+                .compact();
+
+        mockMvc.perform(request(HttpMethod.GET, "/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(invalidToken)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Rotas públicas respondem sem token e não retornam 401")
+    void shouldAllowPublicRoutesWithoutToken() throws Exception {
+        // GET /actuator/health
+        mockMvc.perform(request(HttpMethod.GET, "/actuator/health"))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .isNotEqualTo(HttpStatus.UNAUTHORIZED.value()));
+
+        // POST /auth/login
+        mockMvc.perform(request(HttpMethod.POST, "/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .isNotEqualTo(HttpStatus.UNAUTHORIZED.value()));
+    }
+}

--- a/src/test/java/br/com/fiap/aguiabranca/domain/idea/IdeaIntegrationTest.java
+++ b/src/test/java/br/com/fiap/aguiabranca/domain/idea/IdeaIntegrationTest.java
@@ -1,0 +1,248 @@
+package br.com.fiap.aguiabranca.domain.idea;
+
+import br.com.fiap.aguiabranca.domain.user.Role;
+import br.com.fiap.aguiabranca.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class IdeaIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("POST /ideas cria ideia e responde 201 com Location")
+    void shouldCreateIdeaAndReturn201WithLocation() throws Exception {
+        String token = tokenFor("operador@teste.dev", Role.OPERADOR);
+
+        mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                            "title": "Redução de emissão de CO2",
+                            "description": "Implementar frota elétrica para trajetos curtos."
+                        }
+                        """))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, endsWith("/ideas/1")))
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("Redução de emissão de CO2"))
+                .andExpect(jsonPath("$.description").value("Implementar frota elétrica para trajetos curtos."))
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+    }
+
+    @Test
+    @DisplayName("GET /ideas filtrado por status devolve so o subconjunto pedido")
+    void shouldFilterIdeasByStatus() throws Exception {
+        String gestorToken = tokenFor("gestor@teste.dev", Role.GESTOR);
+        String operadorToken = tokenFor("operador@teste.dev", Role.OPERADOR);
+
+        // Criar primeira ideia (DRAFT)
+        String res1 = mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(operadorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "Ideia 1", "description": "Desc 1"}
+                        """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long idea1Id = objectMapper.readTree(res1).path("id").asLong();
+
+        // Criar segunda ideia e aprovar (APPROVED)
+        String res2 = mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(operadorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "Ideia 2", "description": "Desc 2"}
+                        """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long idea2Id = objectMapper.readTree(res2).path("id").asLong();
+
+        mockMvc.perform(post("/ideas/" + idea2Id + "/approval")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"status": "APPROVED"}
+                        """))
+                .andExpect(status().isOk());
+
+        // Filtrar apenas APPROVED
+        mockMvc.perform(get("/ideas")
+                .param("status", "APPROVED")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(idea2Id))
+                .andExpect(jsonPath("$[0].status").value("APPROVED"));
+
+        // Filtrar apenas DRAFT
+        mockMvc.perform(get("/ideas")
+                .param("status", "DRAFT")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(idea1Id))
+                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+    }
+
+    @Test
+    @DisplayName("Aprovacao por GESTOR muda o status e responde 200")
+    void shouldAllowGestorToApproveIdea() throws Exception {
+        String gestorToken = tokenFor("gestor@teste.dev", Role.GESTOR);
+        String operadorToken = tokenFor("operador@teste.dev", Role.OPERADOR);
+
+        String response = mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(operadorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "Otimizar rotas", "description": "Uso de IA para rotas mais eficientes."}
+                        """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long ideaId = objectMapper.readTree(response).path("id").asLong();
+
+        mockMvc.perform(post("/ideas/" + ideaId + "/approval")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"status": "APPROVED"}
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(ideaId))
+                .andExpect(jsonPath("$.status").value("APPROVED"));
+    }
+
+    @Test
+    @DisplayName("Aprovacao por OPERADOR responde 403")
+    void shouldForbiddenOperadorFromApprovingIdea() throws Exception {
+        String gestorToken = tokenFor("gestor@teste.dev", Role.GESTOR);
+        String operadorToken = tokenFor("operador@teste.dev", Role.OPERADOR);
+
+        String response = mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "Ideia para teste RBAC", "description": "Descricao de teste."}
+                        """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long ideaId = objectMapper.readTree(response).path("id").asLong();
+
+        mockMvc.perform(post("/ideas/" + ideaId + "/approval")
+                .header(HttpHeaders.AUTHORIZATION, bearer(operadorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"status": "APPROVED"}
+                        """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/sem-permissao"))
+                .andExpect(jsonPath("$.title").isNotEmpty())
+                .andExpect(jsonPath("$.status").value(403));
+    }
+
+    @Test
+    @DisplayName("OPERADOR nao enxerga ideia de outro usuario - nem na listagem, nem em GET /ideas/{id} (404)")
+    void shouldIsolateIdeasBetweenDifferentOperadors() throws Exception {
+        String tokenOperador1 = tokenFor("operador1@teste.dev", Role.OPERADOR);
+        String tokenOperador2 = tokenFor("operador2@teste.dev", Role.OPERADOR);
+
+        // Operador 1 cria uma ideia
+        String response = mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(tokenOperador1))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "Ideia Confidencial Operador 1", "description": "Detalhes privados."}
+                        """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long ideaIdOp1 = objectMapper.readTree(response).path("id").asLong();
+
+        // Operador 2 lista ideias -> Nao deve enxergar a ideia do Operador 1
+        mockMvc.perform(get("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(tokenOperador2)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+        // Operador 2 tenta buscar diretamente por ID -> deve responder 404 (sem vazar
+        // existencia com 403 ou 200)
+        mockMvc.perform(get("/ideas/" + ideaIdOp1)
+                .header(HttpHeaders.AUTHORIZATION, bearer(tokenOperador2)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/ideia-nao-encontrada"))
+                .andExpect(jsonPath("$.title").isNotEmpty())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    @DisplayName("Aprovar ideia ja aprovada responde 422")
+    void shouldReturn422WhenApprovingAlreadyReviewedIdea() throws Exception {
+        String gestorToken = tokenFor("gestor@teste.dev", Role.GESTOR);
+
+        String response = mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "Ideia Dupla Revisao", "description": "Teste de regra de negocio."}
+                        """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long ideaId = objectMapper.readTree(response).path("id").asLong();
+
+        // Primeira aprovacao -> 200 OK
+        mockMvc.perform(post("/ideas/" + ideaId + "/approval")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"status": "APPROVED"}
+                        """))
+                .andExpect(status().isOk());
+
+        // Segunda tentativa de aprovacao -> 422 Unprocessable Entity
+        mockMvc.perform(post("/ideas/" + ideaId + "/approval")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"status": "APPROVED"}
+                        """))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/ideia-ja-revisada"))
+                .andExpect(jsonPath("$.title").isNotEmpty())
+                .andExpect(jsonPath("$.status").value(422));
+    }
+
+    @Test
+    @DisplayName("Todos os erros retornados validados como ProblemDetail (type, title, status)")
+    void shouldValidateProblemDetailStructureOnErrors() throws Exception {
+        String gestorToken = tokenFor("gestor@teste.dev", Role.GESTOR);
+
+        // Teste de 404
+        mockMvc.perform(get("/ideas/999999")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/ideia-nao-encontrada"))
+                .andExpect(jsonPath("$.title").exists())
+                .andExpect(jsonPath("$.status").value(404));
+
+        // Teste de 422 Unprocessable Entity (Validacao de payload invalido ao criar
+        // ideia)
+        mockMvc.perform(post("/ideas")
+                .header(HttpHeaders.AUTHORIZATION, bearer(gestorToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "", "description": ""}
+                        """))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.type").value("https://aguiabranca.fiap.br/errors/validacao"))
+                .andExpect(jsonPath("$.title").exists())
+                .andExpect(jsonPath("$.status").value(422));
+    }
+}


### PR DESCRIPTION
Implementa AuthorizationMatrixIntegrationTest: 17 rotas x 3 perfis (51 casos), introspeção via RequestMappingHandlerMapping e testes 401/403. SecurityConfig atualizado com RBAC em nível de URL para garantir 403 antes de @Valid (56/56 testes passando).